### PR TITLE
Attack border

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -37,6 +37,12 @@ export class TerritoryLayer implements Layer {
   private lastRefresh = 0;
 
   private lastFocusedPlayer: PlayerView | null = null;
+  private lastCleanupTick = 0;
+  private hotBorderTiles: Map<TileRef, { expiration: number; color: Colord }> =
+    new Map();
+  private hotBorderColorRed: Colord;
+  private hotBorderColorBlack: Colord;
+  private previousBorderStatus: Map<TileRef, boolean> = new Map();
 
   constructor(
     private game: GameView,
@@ -44,13 +50,18 @@ export class TerritoryLayer implements Layer {
     private transformHandler: TransformHandler,
   ) {
     this.theme = game.config().theme();
+    this.hotBorderColorRed = this.theme.hotBorderColorRed();
+    this.hotBorderColorBlack = this.theme.hotBorderColorBlack();
   }
 
   shouldTransform(): boolean {
     return true;
   }
 
-  async paintPlayerBorder(player: PlayerView) {
+  async paintPlayerBorder(player: PlayerView | null) {
+    if (!player || typeof player.borderTiles !== "function") {
+      return;
+    }
     const tiles = await player.borderTiles();
     tiles.borderTiles.forEach((tile: TileRef) => {
       this.paintTerritory(tile, true); // Immediately paint the tile instead of enqueueing
@@ -59,7 +70,114 @@ export class TerritoryLayer implements Layer {
 
   tick() {
     this.game.recentlyUpdatedTiles().forEach((t) => this.enqueueTile(t));
+
+    const CLEANUP_INTERVAL_TICKS = 10; // Adjust as needed, e.g., 10-30 ticks
+    if (this.game.ticks() - this.lastCleanupTick >= CLEANUP_INTERVAL_TICKS) {
+      this.lastCleanupTick = this.game.ticks(); // Update last cleanup time
+
+      const now = Date.now();
+      // Clean up hot borders
+      for (const [tile, { expiration }] of this.hotBorderTiles.entries()) {
+        if (now > expiration) {
+          this.hotBorderTiles.delete(tile);
+          this.enqueueTile(tile); // Re-queue to repaint to normal state
+        }
+      }
+    }
+
+    const focusedPlayer = this.game.focusedPlayer();
+    const recentlyUpdatedTilesSet = new Set(this.game.recentlyUpdatedTiles());
+
+    const tilesToProcess = new Set<TileRef>();
+    const newPreviousBorderStatus = new Map<TileRef, boolean>();
+    const tilesToEnqueue = new Set<TileRef>(); // Collect tiles to enqueue once
+
+    if (focusedPlayer) {
+      // Add existing hot border tiles
+      for (const tile of this.hotBorderTiles.keys()) {
+        tilesToProcess.add(tile);
+      }
+
+      // Add tiles from previous border status
+      for (const tile of this.previousBorderStatus.keys()) {
+        tilesToProcess.add(tile);
+      }
+
+      // Add recently updated tiles and their neighbors, but only if relevant to focused player's border
+      recentlyUpdatedTilesSet.forEach((updatedTile) => {
+        // Check the updated tile itself
+        if (
+          this.game.owner(updatedTile) === focusedPlayer &&
+          this.game.isBorder(updatedTile)
+        ) {
+          tilesToProcess.add(updatedTile);
+        }
+        // Check neighbors of the updated tile
+        for (const neighbor of this.game.neighbors(updatedTile)) {
+          if (
+            this.game.owner(neighbor) === focusedPlayer &&
+            this.game.isBorder(neighbor)
+          ) {
+            tilesToProcess.add(neighbor);
+          }
+        }
+      });
+
+      for (const tile of tilesToProcess) {
+        const owner = this.game.owner(tile);
+        const isCurrentBorder =
+          owner === focusedPlayer && this.game.isBorder(tile);
+        const wasPreviousBorder = this.previousBorderStatus.get(tile) || false;
+
+        if (isCurrentBorder && !wasPreviousBorder) {
+          // This tile just became a border
+          let hotBorderColor = this.hotBorderColorRed; // Default to red (shrinking)
+
+          if (recentlyUpdatedTilesSet.has(tile)) {
+            // If the tile itself was recently updated, it implies expansion
+            hotBorderColor = this.hotBorderColorBlack;
+          } else {
+            // Check if any neighbor was recently updated (implies shrinking)
+            for (const neighbor of this.game.neighbors(tile)) {
+              if (recentlyUpdatedTilesSet.has(neighbor)) {
+                // If a neighbor was updated, and it's not the current tile, it's likely shrinking
+                hotBorderColor = this.hotBorderColorRed;
+                break;
+              }
+            }
+          }
+
+          this.hotBorderTiles.set(tile, {
+            expiration: Date.now() + 1000,
+            color: hotBorderColor,
+          });
+          tilesToEnqueue.add(tile);
+        } else if (!isCurrentBorder && this.hotBorderTiles.has(tile)) {
+          // Was a hot border but is no longer a border
+          this.hotBorderTiles.delete(tile);
+          tilesToEnqueue.add(tile);
+        } else if (this.hotBorderTiles.has(tile)) {
+          // Still a hot border, re-enqueue to ensure it's painted
+          tilesToEnqueue.add(tile);
+        }
+
+        // Update newPreviousBorderStatus for this tile
+        newPreviousBorderStatus.set(tile, isCurrentBorder);
+      }
+    } else {
+      // If no focused player, clear all hot borders and previous border status
+      this.hotBorderTiles.clear();
+      newPreviousBorderStatus.clear(); // Clear this too
+    }
+
+    // Update previousBorderStatus for the next tick
+    this.previousBorderStatus = newPreviousBorderStatus;
+
+    // Enqueue all tiles that need to be rendered
+    tilesToEnqueue.forEach((t) => this.enqueueTile(t));
+
     const updates = this.game.updatesSinceLastTick();
+
     const unitUpdates = updates !== null ? updates[GameUpdateType.Unit] : [];
     unitUpdates.forEach((update) => {
       if (update.unitType === UnitType.DefensePost) {
@@ -78,7 +196,6 @@ export class TerritoryLayer implements Layer {
       }
     });
 
-    const focusedPlayer = this.game.focusedPlayer();
     if (focusedPlayer !== this.lastFocusedPlayer) {
       if (this.lastFocusedPlayer) {
         this.paintPlayerBorder(this.lastFocusedPlayer);
@@ -267,8 +384,13 @@ export class TerritoryLayer implements Layer {
       return;
     }
     const owner = this.game.owner(tile) as PlayerView;
+    let finalColor = this.theme.territoryColor(owner);
+    let finalAlpha = 150;
+
     if (this.game.isBorder(tile)) {
+      finalAlpha = 255; // Borders are always opaque
       const playerIsFocused = owner && this.game.focusedPlayer() === owner;
+
       if (
         this.game.hasUnitNearby(
           tile,
@@ -277,22 +399,30 @@ export class TerritoryLayer implements Layer {
           owner.id(),
         )
       ) {
-        const borderColors = this.theme.defendedBorderColors(owner);
-        const x = this.game.x(tile);
-        const y = this.game.y(tile);
-        const lightTile =
-          (x % 2 === 0 && y % 2 === 0) || (y % 2 === 1 && x % 2 === 1);
-        const borderColor = lightTile ? borderColors.light : borderColors.dark;
-        this.paintTile(tile, borderColor, 255);
+        // Defense post border
+        if (playerIsFocused && this.hotBorderTiles.has(tile)) {
+          finalColor = this.hotBorderTiles.get(tile)!.color;
+        } else {
+          const borderColors = this.theme.defendedBorderColors(owner);
+          const x = this.game.x(tile);
+          const y = this.game.y(tile);
+          const lightTile =
+            (x % 2 === 0 && y % 2 === 0) || (y % 2 === 1 && x % 2 === 1);
+          finalColor = lightTile ? borderColors.light : borderColors.dark;
+        }
       } else {
-        const useBorderColor = playerIsFocused
-          ? this.theme.focusedBorderColor()
-          : this.theme.borderColor(owner);
-        this.paintTile(tile, useBorderColor, 255);
+        // Regular border
+        if (playerIsFocused && this.hotBorderTiles.has(tile)) {
+          finalColor = this.hotBorderTiles.get(tile)!.color;
+        } else {
+          finalColor = playerIsFocused
+            ? this.theme.focusedBorderColor()
+            : this.theme.borderColor(owner);
+        }
       }
-    } else {
-      this.paintTile(tile, this.theme.territoryColor(owner), 150);
     }
+
+    this.paintTile(tile, finalColor, finalAlpha);
   }
 
   paintTile(tile: TileRef, color: Colord, alpha: number) {
@@ -315,7 +445,10 @@ export class TerritoryLayer implements Layer {
     });
   }
 
-  async enqueuePlayerBorder(player: PlayerView) {
+  async enqueuePlayerBorder(player: PlayerView | null) {
+    if (!player || typeof player.borderTiles !== "function") {
+      return;
+    }
     const playerBorderTiles = await player.borderTiles();
     playerBorderTiles.borderTiles.forEach((tile: TileRef) => {
       this.enqueueTile(tile);

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -187,4 +187,6 @@ export interface Theme {
   allyColor(): Colord;
   enemyColor(): Colord;
   spawnHighlightColor(): Colord;
+  hotBorderColorRed(): Colord;
+  hotBorderColorBlack(): Colord;
 }

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -167,6 +167,6 @@ export class PastelTheme implements Theme {
   }
 
   hotBorderColorBlack(): Colord {
-    return colord({ r: 255, g: 0, b: 0 });
+    return colord({ r: 0, g: 0, b: 0 });
   }
 }

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -161,4 +161,12 @@ export class PastelTheme implements Theme {
   spawnHighlightColor(): Colord {
     return this._spawnHighlightColor;
   }
+
+  hotBorderColorRed(): Colord {
+    return colord({ r: 255, g: 0, b: 0 });
+  }
+
+  hotBorderColorBlack(): Colord {
+    return colord({ r: 255, g: 0, b: 0 });
+  }
 }

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -163,4 +163,12 @@ export class PastelThemeDark implements Theme {
   spawnHighlightColor(): Colord {
     return this._spawnHighlightColor;
   }
+
+  hotBorderColorRed(): Colord {
+    return colord({ r: 255, g: 0, b: 0 });
+  }
+
+  hotBorderColorBlack(): Colord {
+    return colord({ r: 255, g: 0, b: 0 });
+  }
 }

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -169,6 +169,6 @@ export class PastelThemeDark implements Theme {
   }
 
   hotBorderColorBlack(): Colord {
-    return colord({ r: 255, g: 0, b: 0 });
+    return colord({ r: 0, g: 0, b: 0 });
   }
 }

--- a/tests/client/graphics/TerritoryLayer.test.ts
+++ b/tests/client/graphics/TerritoryLayer.test.ts
@@ -1,0 +1,348 @@
+/**
+ * @jest-environment jsdom
+ */
+import { Colord } from "colord";
+import { TerritoryLayer } from "../../../src/client/graphics/layers/TerritoryLayer";
+import { Theme } from "../../../src/core/configuration/Config";
+import { TileRef } from "../../../src/core/game/GameMap";
+import { GameUpdateType } from "../../../src/core/game/GameUpdates";
+import { GameView, PlayerView } from "../../../src/core/game/GameView";
+
+describe("TerritoryLayer", () => {
+  let game: GameView;
+  let eventBus: any;
+  let transformHandler: any;
+  let mockTheme: Theme;
+
+  beforeEach(() => {
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+    const player2: PlayerView = {
+      id: jest.fn(() => 2),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+
+    mockTheme = {
+      teamColor: jest.fn(() => new Colord("#000000")),
+      specialBuildingColor: jest.fn(() => new Colord("#000000")),
+      terrainColor: jest.fn(() => new Colord("#000000")),
+      backgroundColor: jest.fn(() => new Colord("#000000")),
+      falloutColor: jest.fn(() => new Colord("#000000")),
+      font: jest.fn(() => ""),
+      textColor: jest.fn(() => ""),
+      selfColor: jest.fn(() => new Colord("#000000")),
+      territoryColor: jest.fn(() => new Colord("#FFFFFF")),
+      borderColor: jest.fn(() => new Colord("#CCCCCC")),
+      focusedBorderColor: jest.fn(() => new Colord("#AAAAAA")),
+      defendedBorderColors: jest.fn(() => ({
+        light: new Colord("#BBBBBB"),
+        dark: new Colord("#999999"),
+      })),
+      allyColor: jest.fn(() => new Colord("#00FF00")),
+      enemyColor: jest.fn(() => new Colord("#FF0000")),
+      spawnHighlightColor: jest.fn(() => new Colord("#FFFF00")),
+      hotBorderColorRed: jest.fn(() => new Colord("#FF0000")),
+      hotBorderColorBlack: jest.fn(() => new Colord("#000000")),
+    };
+
+    game = {
+      config: jest.fn(() => ({
+        theme: jest.fn(() => mockTheme),
+      })) as any,
+      owner: jest.fn(),
+      isBorder: jest.fn(),
+      recentlyUpdatedTiles: jest.fn(),
+      neighbors: jest.fn((tileRef: TileRef) => {
+        const x = tileRef % 10;
+        const y = Math.floor(tileRef / 10);
+        const neighbors: TileRef[] = [];
+        // Assuming a 10x10 grid for simplicity
+        if (x > 0) neighbors.push(tileRef - 1); // Left
+        if (x < 9) neighbors.push(tileRef + 1); // Right
+        if (y > 0) neighbors.push(tileRef - 10); // Up
+        if (y < 9) neighbors.push(tileRef + 10); // Down
+        return neighbors;
+      }),
+      ticks: jest.fn(() => 0),
+      focusedPlayer: jest.fn(() => player1),
+      updatesSinceLastTick: jest.fn(() => {
+        const updates: any = [];
+        for (let i = 0; i <= GameUpdateType.BomberExplosion; i++) {
+          updates[i] = [];
+        }
+        return updates;
+      }),
+      x: jest.fn((tileRef: TileRef) => tileRef % 10), // Assuming a 10x10 grid
+      y: jest.fn((tileRef: TileRef) => Math.floor(tileRef / 10)), // Assuming a 10x10 grid
+      width: jest.fn(() => 10), // Assuming a 10x10 grid
+      hasUnitNearby: jest.fn(),
+      unitInfo: jest.fn(),
+      myPlayer: jest.fn(() => player1), // Directly return player1
+      // Public methods from GameView that TerritoryLayer might call
+      isOnEdgeOfMap: jest.fn(),
+      update: jest.fn(),
+      alliances: jest.fn(() => []),
+      nearbyUnits: jest.fn(() => []),
+      myClientID: jest.fn(() => "mockClientID"),
+      player: jest.fn((id: string) =>
+        id === player1.id() ? player1 : player2,
+      ), // Return player1 or player2 based on ID
+      players: jest.fn(() => [player1, player2]),
+      playerBySmallID: jest.fn((id: number) =>
+        id.toString() === player1.id() ? player1 : player2,
+      ), // Return player1 or player2 based on ID
+      playerByClientID: jest.fn((id: string) =>
+        id === "mockClientID" ? player1 : null,
+      ), // Return player1 if clientID matches
+      hasPlayer: jest.fn(() => true),
+      playerViews: jest.fn(() => [player1, player2]),
+      inSpawnPhase: jest.fn(() => false),
+      units: jest.fn(() => []),
+      unit: jest.fn(),
+      ref: jest.fn(),
+      cell: jest.fn(),
+      height: jest.fn(() => 10),
+      numLandTiles: jest.fn(() => 0),
+      isValidCoord: jest.fn(() => true),
+      isLand: jest.fn(() => false),
+      isOceanShore: jest.fn(() => false),
+      isOcean: jest.fn(() => false),
+      isShoreline: jest.fn(() => false),
+      magnitude: jest.fn(() => 0),
+      ownerID: jest.fn(() => 0),
+      hasOwner: jest.fn(() => false),
+      setOwnerID: jest.fn(),
+      hasFallout: jest.fn(() => false),
+      setFallout: jest.fn(),
+      isWater: jest.fn(() => false),
+      isLake: jest.fn(() => false),
+      isShore: jest.fn(() => false),
+      cost: jest.fn(() => 0),
+      terrainType: jest.fn(),
+      forEachTile: jest.fn(),
+      manhattanDist: jest.fn(() => 0),
+      euclideanDistSquared: jest.fn(() => 0),
+      bfs: jest.fn(() => new Set()),
+      toTileUpdate: jest.fn(() => BigInt(0)),
+      updateTile: jest.fn(() => 0),
+      numTilesWithFallout: jest.fn(() => 0),
+      gameID: jest.fn(() => "mockGameID"),
+      setFocusedPlayer: jest.fn(),
+    } as unknown as GameView;
+    eventBus = { on: jest.fn() };
+    transformHandler = {};
+  });
+
+  it("should initialize without errors", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    expect(layer).toBeDefined();
+  });
+
+  it("should add and remove hot border tiles based on changes", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    const tile1: TileRef = 0;
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+
+    // Mock initial state
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player1);
+    (game.owner as jest.Mock).mockReturnValue(player1);
+    (game.isBorder as jest.Mock).mockReturnValue(false);
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([]);
+    (game.neighbors as jest.Mock).mockReturnValue([]);
+    (game.ticks as jest.Mock).mockReturnValue(1);
+
+    // Simulate tile becoming a border (expansion)
+    (game.isBorder as jest.Mock).mockImplementation(
+      (tile: TileRef) => tile === tile1,
+    );
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([tile1]);
+    layer.tick();
+
+    // Check if tile1 is a hot border (black for expansion)
+    // Accessing private property for testing purposes
+    expect((layer as any).hotBorderTiles.has(tile1)).toBe(true);
+    expect((layer as any).hotBorderTiles.get(tile1).color.toHex()).toBe(
+      mockTheme.hotBorderColorBlack().toHex(),
+    );
+
+    // Simulate time passing and tile no longer being a border
+    (game.ticks as jest.Mock).mockReturnValue(100); // Advance ticks for cleanup
+    (game.isBorder as jest.Mock).mockReturnValue(false); // No longer a border
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([]); // No recent updates
+    layer.tick();
+
+    // Check if tile1 is removed from hot borders after cleanup and no longer a border
+    expect((layer as any).hotBorderTiles.has(tile1)).toBe(false);
+  });
+
+  it("should apply red color for contracting borders", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    const tile1: TileRef = 0;
+    const tile2: TileRef = 1; // Neighbor
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+
+    // Initial state: tile1 is a border, tile2 is its neighbor and recently updated
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player1);
+    (game.owner as jest.Mock).mockReturnValue(player1);
+    (game.isBorder as jest.Mock).mockImplementation(
+      (tile: TileRef) => tile === tile1,
+    );
+    (game.neighbors as jest.Mock).mockImplementation((tile: TileRef) => {
+      if (tile === tile1) return [tile2];
+      if (tile === tile2) return [tile1];
+      return [];
+    });
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([tile2]); // Neighbor updated, implies contraction
+    (game.ticks as jest.Mock).mockReturnValue(1);
+
+    layer.tick();
+
+    // Check if tile1 is a hot border (red for contraction)
+    expect((layer as any).hotBorderTiles.has(tile1)).toBe(true);
+    expect((layer as any).hotBorderTiles.get(tile1).color.toHex()).toBe(
+      mockTheme.hotBorderColorRed().toHex(),
+    );
+  });
+
+  it("should apply black color for expanding borders", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    const tile1: TileRef = 0;
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+
+    // Initial state: tile1 is a border and recently updated
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player1);
+    (game.owner as jest.Mock).mockReturnValue(player1);
+    (game.isBorder as jest.Mock).mockImplementation(
+      (tile: TileRef) => tile === tile1,
+    );
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([tile1]); // Tile itself updated, implies expansion
+    (game.neighbors as jest.Mock).mockReturnValue([]);
+    (game.ticks as jest.Mock).mockReturnValue(1);
+
+    layer.tick();
+
+    // Check if tile1 is a hot border (black for expansion)
+    expect((layer as any).hotBorderTiles.has(tile1)).toBe(true);
+    expect((layer as any).hotBorderTiles.get(tile1).color.toHex()).toBe(
+      mockTheme.hotBorderColorBlack().toHex(),
+    );
+  });
+
+  it("should clear hot borders when focused player changes", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    const tile1: TileRef = 0;
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+    const player2: PlayerView = { id: jest.fn(() => 2) } as any;
+
+    // Simulate tile becoming a hot border for player1
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player1);
+    (game.owner as jest.Mock).mockReturnValue(player1);
+    (game.isBorder as jest.Mock).mockImplementation(
+      (tile: TileRef) => tile === tile1,
+    );
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([tile1]);
+    (game.ticks as jest.Mock).mockReturnValue(1);
+    layer.tick();
+    expect((layer as any).hotBorderTiles.has(tile1)).toBe(true);
+
+    // Change focused player
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player2);
+    (game.ticks as jest.Mock).mockReturnValue(2);
+    layer.tick();
+
+    // Hot borders should be cleared
+    expect((layer as any).hotBorderTiles.size).toBe(0);
+  });
+
+  it("should clear hot borders when focused player becomes null", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    const tile1: TileRef = 0;
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+
+    // Simulate tile becoming a hot border for player1
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player1);
+    (game.owner as jest.Mock).mockReturnValue(player1);
+    (game.isBorder as jest.Mock).mockImplementation(
+      (tile: TileRef) => tile === tile1,
+    );
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([tile1]);
+    (game.ticks as jest.Mock).mockReturnValue(1);
+    layer.tick();
+    expect((layer as any).hotBorderTiles.has(tile1)).toBe(true);
+
+    // Set focused player to null
+    (game.focusedPlayer as jest.Mock).mockReturnValue(null);
+    (game.ticks as jest.Mock).mockReturnValue(2);
+    layer.tick();
+
+    // Hot borders should be cleared
+    expect((layer as any).hotBorderTiles.size).toBe(0);
+  });
+
+  it("should update previousBorderStatus correctly", () => {
+    const layer = new TerritoryLayer(game, eventBus, transformHandler);
+    const tile1: TileRef = 0;
+    const player1: PlayerView = {
+      id: jest.fn(() => 1),
+      borderTiles: jest.fn(() =>
+        Promise.resolve({ borderTiles: new Set<TileRef>() }),
+      ),
+    } as any;
+
+    // Initial state: tile1 is not a border
+    (game.focusedPlayer as jest.Mock).mockReturnValue(player1);
+    (game.owner as jest.Mock).mockReturnValue(player1);
+    (game.isBorder as jest.Mock).mockReturnValue(false);
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([]);
+    (game.ticks as jest.Mock).mockReturnValue(1);
+    layer.tick();
+    expect((layer as any).previousBorderStatus.get(tile1)).toBeUndefined();
+
+    // Simulate tile1 becoming a border
+    (game.isBorder as jest.Mock).mockImplementation(
+      (tile: TileRef) => tile === tile1,
+    );
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([tile1]);
+    (game.ticks as jest.Mock).mockReturnValue(2);
+    layer.tick();
+    expect((layer as any).previousBorderStatus.get(tile1)).toBe(true);
+
+    // Simulate tile1 no longer being a border
+    (game.isBorder as jest.Mock).mockReturnValue(false);
+    (game.recentlyUpdatedTiles as jest.Mock).mockReturnValue([]);
+    (game.ticks as jest.Mock).mockReturnValue(3);
+    layer.tick();
+    expect((layer as any).previousBorderStatus.get(tile1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description:
![chrome_hUF6TgBfKG](https://github.com/user-attachments/assets/038d5fd3-df40-4a57-9794-eea47659b889)

This PR introduces dynamic visual feedback for territory borders, enhancing the player's understanding of map changes. Borders of the focused player's territory will now briefly highlight in different colors to indicate whether the
 territory is expanding or contracting.

 -   **Expanding Borders (Red):** When a player's territory expands, newly formed borders will briefly appear black.
 -   **Contracting Borders (Red):** When a player's territory contracts, affected borders will briefly appear red.

 This feature provides immediate visual cues, making it easier for players to track the ebb and flow of their territory and react to changes more effectively.

  Technical Description:

This PR implements dynamic "hot borders" on the `TerritoryLayer` to provide visual feedback on territory changes.

 **Key Changes:**

 -   **`TerritoryLayer.ts`:**
     -   Introduced `hotBorderTiles` (Map<TileRef, { expiration: number; color: Colord }>) to store tiles currently displaying a hot border effect, along with their expiration time and color.
     -   Added `previousBorderStatus` (Map<TileRef, boolean>) to track the border status of tiles in the previous tick, enabling detection of changes.
     -   Modified the `tick()` method to:
        -   Implement a cleanup mechanism for expired `hotBorderTiles`.
         -   Iterate through recently updated tiles and their neighbors to identify new or changing border tiles for the focused player.
         -   Determine the "hot border" color (red for contraction, red (for now, polling it) for expansion) based on whether the tile itself or its neighbors were recently updated.
         -   Update `hotBorderTiles` and `previousBorderStatus` accordingly.
         -   Enqueue affected tiles for repainting.
     -   Updated the `paintTile()` method to apply the `hotBorderTiles` color if a tile is a hot border and the player is focused, overriding the default border colors.
 -   **`Config.ts`:**
     -   Added `hotBorderColorRed()` and `hotBorderColorBlack()` methods to the `Theme` interface.
 -   **`PastelTheme.ts` and `PastelThemeDark.ts`:**
     -   Implemented `hotBorderColorRed()` and `hotBorderColorBlack()` to define the specific red and black colors for the hot border effects.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
