### PR TITLE
feat: Implement bomber cap per target for improved efficiency and performance

### DIFF
--- a/src/core/execution/BomberExecution.ts
+++ b/src/core/execution/BomberExecution.ts
@@ -15,6 +15,7 @@ export class BomberExecution implements Execution {
     private origOwner: Player,
     private sourceAirfield: Unit,
     private targetTile: TileRef,
+    private bombersOnTarget: Map<TileRef, number>,
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -31,6 +32,10 @@ export class BomberExecution implements Execution {
       );
       if (!spawn) {
         this.active = false;
+        this.bombersOnTarget.set(
+          this.targetTile,
+          (this.bombersOnTarget.get(this.targetTile) ?? 1) - 1,
+        );
         return;
       }
       this.bomber = this.origOwner.buildUnit(UnitType.Bomber, spawn, {
@@ -39,6 +44,10 @@ export class BomberExecution implements Execution {
     }
     if (!this.bomber.isActive()) {
       this.active = false;
+      this.bombersOnTarget.set(
+        this.targetTile,
+        (this.bombersOnTarget.get(this.targetTile) ?? 1) - 1,
+      );
       return;
     }
     if (!this.returning && this.bombsLeft > 0) {
@@ -65,6 +74,10 @@ export class BomberExecution implements Execution {
       } else if (this.returning) {
         this.bomber.delete(true);
         this.active = false;
+        this.bombersOnTarget.set(
+          this.targetTile,
+          (this.bombersOnTarget.get(this.targetTile) ?? 1) - 1,
+        );
       }
       return;
     }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -607,6 +607,7 @@ export interface Player {
     intent: { targetPlayerID: string; structure: UnitType } | null,
   ): void;
   getBomberIntent(): { targetPlayerID: string; structure: UnitType } | null;
+  bombersOnTarget: Map<TileRef, number>;
 
   setAutoBombingEnabled(enabled: boolean): void;
   isAutoBombingEnabled(): boolean;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -112,6 +112,7 @@ export class PlayerImpl implements Player {
   private bomberIntent: { targetPlayerID: string; structure: UnitType } | null =
     null;
   private _autoBombingEnabled: boolean = false;
+  public bombersOnTarget = new Map<TileRef, number>();
 
   constructor(
     private mg: GameImpl,


### PR DESCRIPTION
## Description:
Problem:
Previously, multiple bombers could be dispatched to the same target without a cap, leading to inefficient resource allocation and potential over-bombing of single structures. This could also contribute to localized performance dips due to a high concentration of bomber-related calculations on a single target. An earlier attempt to implement a cap suffered from a race condition, where individual airfields were not aware of bombers launched by other airfields in the same tick.

Solution:
This PR introduces a robust system to cap the number of bombers targeting a single enemy structure at 6.

*   **Centralized Tracking:** The `bombersOnTarget` map has been moved from individual `AirfieldExecution` instances to the `Player` object. This ensures a single, authoritative source of truth for all airfields belonging to a player, eliminating race conditions.
*   **Intelligent Target Selection:** `AirfieldExecution` now checks the centralized `player.bombersOnTarget` map before launching a bomber. If the highest-priority target already has 6 bombers en route, the system will automatically "spill over" and select the next available high-priority target that is under the cap.
*   **Lifecycle Management:** `BomberExecution` now decrements the count for its target in the `player.bombersOnTarget` map when the bomber is destroyed or returns to base, freeing up the slot for future bombers.
![chrome_veO29FOMwd](https://github.com/user-attachments/assets/2da7a6c5-5f29-4fee-b9a8-494554577af8)

Benefits:
*   **Improved Bomber Efficiency:** Bombers are now intelligently distributed across multiple enemy targets, maximizing their impact and preventing wasted attacks.
*   **Reduced Over-bombing:** Prevents excessive bombers from being sent to a single target that is already sufficiently attacked or destroyed.
*   **Potential Performance Improvement:** By spreading out bomber activity, this change can help mitigate localized processing spikes that might occur when many bombers converge on a single point.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777