### PR TITLE
Optimize StraightPathFinder for bombers to reduce expensive square root calculations

### DIFF
--- a/src/core/pathfinding/PathFinding.ts
+++ b/src/core/pathfinding/PathFinding.ts
@@ -99,11 +99,13 @@ export class StraightPathFinder {
     const dx = dstX - currX;
     const dy = dstY - currY;
 
-    const dist = Math.hypot(dx, dy);
+    const distSq = dx * dx + dy * dy;
 
-    if (dist <= speed) {
+    if (distSq <= speed * speed) {
       return true;
     }
+
+    const dist = Math.sqrt(distSq);
 
     const dirX = dx / dist;
     const dirY = dy / dist;


### PR DESCRIPTION
## Description:
 The game was stuttering because too many units were performing expensive calculations at the same time, overloading the server. We made a change to bomber pathfinding to improve this:

-    Faster Air Unit Movement: We optimized the movement calculation for Bombers and Fighter Jets. Previously, every air unit performed a slow "square root" calculation every tick. We changed it to use a much faster method first, only using the slow calculation when absolutely necessary.

https://imgur.com/RzRfUde

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
