### PR TITLE
Reduce A* iterations for Tradeships and Warships

### DIFF
--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -28,7 +28,7 @@ export class TradeShipExecution implements Execution {
 
   init(mg: Game, ticks: number): void {
     this.mg = mg;
-    this.pathFinder = PathFinder.Mini(mg, 2500);
+    this.pathFinder = PathFinder.Mini(mg, 1000);
   }
 
   tick(ticks: number): void {

--- a/src/core/execution/WarshipExecution.ts
+++ b/src/core/execution/WarshipExecution.ts
@@ -27,7 +27,7 @@ export class WarshipExecution implements Execution {
 
   init(mg: Game, ticks: number): void {
     this.mg = mg;
-    this.pathfinder = PathFinder.Mini(mg, 5000);
+    this.pathfinder = PathFinder.Mini(mg, 2500);
     this.random = new PseudoRandom(mg.ticks());
     if (isUnit(this.input)) {
       this.warship = this.input;


### PR DESCRIPTION
## Description:
Split from #12 
 The game was stuttering because too many units were performing expensive calculations at the same time, overloading the server. We made a changes to fix this:

   1. Smarter Ship Pathfinding: We significantly reduced the "thinking time" (A\* iterations) the server uses to calculate paths for *Tradeships and Warships*. This prevents them from causing lag when many are active, with a minimal trade-off in how quickly they calculate very long-distance routes.

- Reduce A* iterations for TradeShipExecution to 1000
- Reduce A* iterations for WarshipExecution to 2500

https://imgur.com/RzRfUde

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777

