### PR TITLE
feat(ui): Improve radial and build menu interaction

### DIFF
--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -18,6 +18,7 @@ import { translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
 import { Gold, UnitType } from "../../../core/game/Game";
 import { GameView } from "../../../core/game/GameView";
+import { CloseViewEvent } from "../../InputHandler";
 import { renderNumber } from "../../Utils";
 import { UIState } from "../UIState";
 
@@ -366,6 +367,7 @@ export class BuildMenu extends LitElement {
     } else {
       this.uiState.pendingBuildUnitType = item.unitType;
     }
+    this.eventBus.emit(new CloseViewEvent());
     this.requestUpdate();
   };
 

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -138,9 +138,7 @@ export class RadialMenu implements Layer {
     const pie = d3
       .pie<any>()
       .value(() => 1)
-      .padAngle(0.03)
-      .startAngle(Math.PI / 4) // Start at 45 degrees (π/4 radians)
-      .endAngle(2 * Math.PI + Math.PI / 4); // Complete the circle but shifted by 45 degrees
+      .padAngle(0.03);
 
     const arc = d3
       .arc<any>()


### PR DESCRIPTION
## Description:
This pull request introduces two quality-of-life improvements to the user interface, focusing on the radial menu and its  interaction with the build menu.

![chrome_a6lRVAYpKz](https://github.com/user-attachments/assets/d69bcd9d-4874-4151-b9b7-0e1fc4795497)

Key Changes:

   1. Close Radial Menu on Build Selection:
       * Problem: Previously, the radial menu would remain open after a user selected an item from the build menu, obstructing the map view and requiring an extra click to close.
       * Solution: The radial menu now closes automatically as soon as an item is selected from the build menu. This is achieved
         by emitting a CloseViewEvent from the BuildMenu component, which the RadialMenu already listens for.

   2. Fix Radial Menu Layout:
       * Problem: With the removal of the "Build" option from the radial menu, the remaining three items were left in a skewed,
         asymmetrical layout. This was caused by a hardcoded 45-degree rotation intended for a four-item menu.
       * Solution: The unnecessary rotation (startAngle and endAngle) has been removed from the D3 pie chart generator. This
         allows D3's default behavior to correctly and symmetrically position the three menu items.

_Prettier error is already fixed in PR 22 and 24 so did not add that here._



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
