### PR TITLE
Fix(ui): Prevent build panel race condition on hover and click

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -82,6 +82,8 @@ export class ControlPanel extends LitElement implements Layer {
 
   private _hoverTimeoutId: number | null = null; // New property
 
+  private _ignoreNextClick = false;
+
   init() {
     this.attackRatio = Number(
       localStorage.getItem("settings.attackRatio") ?? "0.3",
@@ -203,10 +205,18 @@ export class ControlPanel extends LitElement implements Layer {
     if (!this.isBuildPanelOpen) {
       this.isBuildPanelOpen = true;
       this.eventBus.emit(new ToggleBuildPanelEvent(true));
+      this._ignoreNextClick = true;
+      setTimeout(() => {
+        this._ignoreNextClick = false;
+      }, 200);
     }
   }
 
   toggleBuildPanel() {
+    if (this._ignoreNextClick) {
+      this._ignoreNextClick = false;
+      return;
+    }
     this.isBuildPanelOpen = !this.isBuildPanelOpen;
     this.eventBus.emit(new ToggleBuildPanelEvent(this.isBuildPanelOpen));
   }


### PR DESCRIPTION
## Description:
This PR fixes a race condition where the build panel would open and immediately close if the user clicked on the 'Build' tab shortly after hovering over it.

### Problem

The 'Build' tab in the control panel would open on hover (with a 300ms delay) and also toggle on click. This created a race condition where a user would hover, see the panel open, and then click to interact with it, which would immediately toggle the panel closed.
![chrome_XFKdT6ZSCG](https://github.com/user-attachments/assets/ca8ea4c2-9bf6-471b-9818-a0ef3bc51044)

### Solution

A 'debounce' mechanism was implemented to prevent the click from being registered immediately after a hover-triggered open.

- A new `_ignoreNextClick` flag is set to `true` when the panel is opened via hover.
- A 200ms timer is started at the same time.
- If a click event occurs during this 200ms window, the event is ignored, and the flag is reset.
- After the timer completes, the flag is reset, and click events are handled normally.

This ensures that both hover-to-open and click-to-toggle functionalities are preserved while preventing the conflicting interaction.
![chrome_f3qqhdA55O](https://github.com/user-attachments/assets/c1e643f1-ee8a-44bc-a2f2-fbe5d7d9d288)

### Technical Changes

-   **`src/client/graphics/layers/ControlPanel.ts`**:
    -   Added a new private property `_ignoreNextClick`.
    -   Modified `openBuildPanel()` to set the `_ignoreNextClick` flag and start a 200ms timer to reset it.
    -   Modified `toggleBuildPanel()` to check for the `_ignoreNextClick` flag and ignore the click if it's set.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
