### PR TITLE
Implement New Economy Research Upgrades

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -582,6 +582,8 @@
     "missile_failed_intercept": "Missile failed to intercept target",
     "domestic_trade_summary": "You received {goldAmount} gold from domestic trade in the last 30 seconds.",
     "international_trade_origin": "Your cargo truck successfully delivered goods to {destinationName}. You received {goldAmount} gold.",
-    "international_trade_destination": "A cargo truck from {originName} arrived. You received {goldAmount} gold."
+    "international_trade_destination": "A cargo truck from {originName} arrived. You received {goldAmount} gold.",
+    "insurance_refund": "Insurance refund {amount} gold",
+    "insurance_refund_conquest": "Insurance refund {amount} gold for conquered structure"
   }
 }

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -120,6 +120,7 @@ export function getMessageTypeClasses(type: MessageType): string {
     case MessageType.CAPTURED_ENEMY_UNIT:
     case MessageType.RECEIVED_GOLD_FROM_TRADE:
     case MessageType.CONQUERED_PLAYER:
+    case MessageType.INSURANCE_REFUND:
       return severityColors["success"];
     case MessageType.ATTACK_FAILED:
     case MessageType.ALLIANCE_REJECTED:

--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -1127,19 +1127,22 @@ export class ControlPanel2 extends LitElement implements Layer {
                       ? html`
                           <div class="grid grid-cols-3 gap-4">
                             ${renderUpgradeButton(
-                              UpgradeType.EconomyUpgrade1,
-                              "Econ 1",
+                              UpgradeType.UrbanPlanning,
+                              "Urban Planning",
                               1,
+                              "Increases maximum population capacity by 25%",
                             )}
                             ${renderUpgradeButton(
-                              UpgradeType.EconomyUpgrade2,
-                              "Econ 2",
+                              UpgradeType.StructureInsurance,
+                              "Structure Insurance",
                               2,
+                              "Refunds 33% of a building's cost upon destruction",
                             )}
                             ${renderUpgradeButton(
-                              UpgradeType.EconomyUpgrade3,
-                              "Econ 3",
+                              UpgradeType.Automation,
+                              "Automation",
                               3,
+                              "Doubles internal trade income, but slows troop regeneration by 20%",
                             )}
                           </div>
                         `

--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -378,12 +378,18 @@ export class EventsDisplay extends LitElement implements Layer {
     }
 
     let description: string = event.message;
+    const params = event.params;
+
+    if (event.messageType === MessageType.INSURANCE_REFUND && params?.amount) {
+      params.amount = renderNumber(Number(params.amount));
+    }
+
     // Check if the message is a translation key (starts with "events_display." or "messages.")
     if (
       event.message.startsWith("events_display.") ||
       event.message.startsWith("messages.")
     ) {
-      description = translateText(event.message, event.params);
+      description = translateText(event.message, params);
     }
 
     this.addEvent({

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -192,6 +192,14 @@ export interface Config {
   isReplay(): boolean;
   allianceExtensionPromptOffset(): number;
   maxProductivity(): number;
+  urbanPlanningPopulationBonusNum(): number;
+  urbanPlanningPopulationBonusDen(): number;
+  structureInsuranceRefundNum(): number;
+  structureInsuranceRefundDen(): number;
+  automationTradeIncomeMultiplierNum(): number;
+  automationTradeIncomeMultiplierDen(): number;
+  automationTroopRegenMultiplierNum(): number;
+  automationTroopRegenMultiplierDen(): number;
 }
 
 export interface Theme {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -662,11 +662,11 @@ export class DefaultConfig implements Config {
         return { cost: costForPlayer(3_000_000n) };
 
       // Economy
-      case UpgradeType.EconomyUpgrade1:
+      case UpgradeType.UrbanPlanning:
         return { cost: costForPlayer(1_000_000n) };
-      case UpgradeType.EconomyUpgrade2:
+      case UpgradeType.StructureInsurance:
         return { cost: costForPlayer(2_000_000n) };
-      case UpgradeType.EconomyUpgrade3:
+      case UpgradeType.Automation:
         return { cost: costForPlayer(3_000_000n) };
 
       default:
@@ -915,11 +915,17 @@ export class DefaultConfig implements Config {
   }
 
   maxPopulation(player: Player | PlayerView): number {
-    const maxPop =
+    let maxPop =
       player.type() === PlayerType.Human && this.infiniteTroops()
         ? 1_000_000_000
         : 1 * (player.numTilesOwned() * 30 + 50000) +
           player.effectiveUnits(UnitType.City) * this.cityPopulationIncrease();
+
+    if (player.hasUpgrade(UpgradeType.UrbanPlanning)) {
+      const num = this.urbanPlanningPopulationBonusNum();
+      const den = this.urbanPlanningPopulationBonusDen();
+      maxPop = Math.floor((maxPop * num) / den);
+    }
 
     if (player.type() === PlayerType.Bot) {
       return maxPop / 2;
@@ -952,6 +958,12 @@ export class DefaultConfig implements Config {
     const totalPop = player.totalPopulation();
     const ratio = Math.max(1 - totalPop / max, 0);
     toAdd *= ratio ** 1.222;
+
+    if (player.hasUpgrade(UpgradeType.Automation)) {
+      const num = this.automationTroopRegenMultiplierNum();
+      const den = this.automationTroopRegenMultiplierDen();
+      toAdd = (toAdd * num) / den;
+    }
 
     if (player.type() === PlayerType.Bot) {
       toAdd *= 0.7;
@@ -1108,5 +1120,30 @@ export class DefaultConfig implements Config {
 
   internationalCargoTruckGoldSplitRatio(): number {
     return 0.5; // 50/50 split
+  }
+
+  urbanPlanningPopulationBonusNum(): number {
+    return 5;
+  }
+  urbanPlanningPopulationBonusDen(): number {
+    return 4;
+  }
+  structureInsuranceRefundNum(): number {
+    return 1;
+  }
+  structureInsuranceRefundDen(): number {
+    return 3;
+  }
+  automationTradeIncomeMultiplierNum(): number {
+    return 2;
+  }
+  automationTradeIncomeMultiplierDen(): number {
+    return 1;
+  }
+  automationTroopRegenMultiplierNum(): number {
+    return 4;
+  }
+  automationTroopRegenMultiplierDen(): number {
+    return 5;
   }
 }

--- a/src/core/execution/PurchaseUpgradeExecution.ts
+++ b/src/core/execution/PurchaseUpgradeExecution.ts
@@ -1,4 +1,4 @@
-import { Execution, Player, UpgradeType } from "../game/Game";
+import { Execution, Player, PlayerType, UpgradeType } from "../game/Game";
 import { GameImpl } from "../game/GameImpl";
 
 export class PurchaseUpgradeExecution implements Execution {
@@ -44,6 +44,16 @@ export class PurchaseUpgradeExecution implements Execution {
     if (this.player.gold() >= cost) {
       this.player.removeGold(cost);
       this.player.addUpgrade(this.upgrade);
+
+      // If a bot just purchased the Roads upgrade, give it all the eco upgrades.
+      if (
+        this.player.type() === PlayerType.Bot &&
+        this.upgrade === UpgradeType.Roads
+      ) {
+        this.player.addUpgrade(UpgradeType.UrbanPlanning);
+        this.player.addUpgrade(UpgradeType.StructureInsurance);
+        this.player.addUpgrade(UpgradeType.Automation);
+      }
 
       if (this.upgrade === UpgradeType.StructureInsurance) {
         this.player.units().forEach((unit) => {

--- a/src/core/execution/PurchaseUpgradeExecution.ts
+++ b/src/core/execution/PurchaseUpgradeExecution.ts
@@ -45,6 +45,12 @@ export class PurchaseUpgradeExecution implements Execution {
       this.player.removeGold(cost);
       this.player.addUpgrade(this.upgrade);
 
+      if (this.upgrade === UpgradeType.StructureInsurance) {
+        this.player.units().forEach((unit) => {
+          unit.insure(this.player);
+        });
+      }
+
       if (this.upgrade === UpgradeType.ScorchedEarth) {
         this.mg.destroyPlayerRoads(this.player);
         this.player.removeUpgrade(UpgradeType.Roads);

--- a/src/core/game/CargoManager.ts
+++ b/src/core/game/CargoManager.ts
@@ -190,7 +190,16 @@ export class CargoManager {
           }
         } else {
           // --- REVISED: Domestic Arrival ---
-          const gold = this.game.config().cargoTruckGold(truck.path.length);
+          let gold = this.game.config().cargoTruckGold(truck.path.length);
+          if (truck.owner.hasUpgrade(UpgradeType.Automation)) {
+            const num = BigInt(
+              this.game.config().automationTradeIncomeMultiplierNum(),
+            );
+            const den = BigInt(
+              this.game.config().automationTradeIncomeMultiplierDen(),
+            );
+            gold = (gold * num) / den;
+          }
           truck.owner.addGold(gold);
           const currentGold =
             this.domesticGoldSinceLastMessage.get(truck.owner.id()) ?? 0n;

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -453,6 +453,9 @@ export interface Unit {
   returning(): boolean;
   setReturning(returning: boolean): void;
 
+  // Insurance
+  insure(player: Player): void;
+
   // Health
   hasHealth(): boolean;
   retreating(): boolean;
@@ -807,6 +810,7 @@ export enum MessageType {
   CHAT,
   WARN,
   PEACE_TIMER_BLOCKED,
+  INSURANCE_REFUND,
 }
 
 // Message categories used for filtering events in the EventsDisplay
@@ -815,6 +819,7 @@ export enum MessageCategory {
   ALLIANCE = "ALLIANCE",
   TRADE = "TRADE",
   CHAT = "CHAT",
+  FINANCIAL = "FINANCIAL",
 }
 
 // Ensures that all message types are included in a category
@@ -845,6 +850,7 @@ export const MESSAGE_TYPE_CATEGORIES: Record<MessageType, MessageCategory> = {
   [MessageType.SENT_TROOPS_TO_PLAYER]: MessageCategory.TRADE,
   [MessageType.RECEIVED_TROOPS_FROM_PLAYER]: MessageCategory.TRADE,
   [MessageType.CHAT]: MessageCategory.CHAT,
+  [MessageType.INSURANCE_REFUND]: MessageCategory.FINANCIAL,
 } as const;
 
 /**

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -180,10 +180,10 @@ export enum UpgradeType {
   AirUpgrade2 = "AirUpgrade2",
   AirUpgrade3 = "AirUpgrade3",
 
-  // Dummy Economy Upgrades
-  EconomyUpgrade1 = "EconomyUpgrade1",
-  EconomyUpgrade2 = "EconomyUpgrade2",
-  EconomyUpgrade3 = "EconomyUpgrade3",
+  // Economy Upgrades
+  UrbanPlanning = "UrbanPlanning",
+  StructureInsurance = "StructureInsurance",
+  Automation = "Automation",
 }
 
 const _structureTypes: ReadonlySet<UnitType> = new Set([

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -1,12 +1,14 @@
 import { simpleHash, toInt, withinInt } from "../Util";
 import {
   AllUnitParams,
+  isStructureType,
   MessageType,
   Player,
   Tick,
   Unit,
   UnitInfo,
   UnitType,
+  UpgradeType,
 } from "./Game";
 import { GameImpl } from "./GameImpl";
 import { TileRef } from "./GameMap";
@@ -33,6 +35,7 @@ export class UnitImpl implements Unit {
   private _level: number = 1;
   private _targetable: boolean = true;
   private _accumulatedRegen: number = 0;
+  private _insuredBy: Player | null = null;
 
   constructor(
     private _type: UnitType,
@@ -55,6 +58,13 @@ export class UnitImpl implements Unit {
       "patrolTile" in params ? (params.patrolTile ?? undefined) : undefined;
     this._targetUnit =
       "targetUnit" in params ? (params.targetUnit ?? undefined) : undefined;
+
+    if (
+      isStructureType(this._type) &&
+      this._owner.hasUpgrade(UpgradeType.StructureInsurance)
+    ) {
+      this._insuredBy = this._owner;
+    }
 
     switch (this._type) {
       case UnitType.Warship:
@@ -171,6 +181,24 @@ export class UnitImpl implements Unit {
   }
 
   setOwner(newOwner: PlayerImpl): void {
+    if (this._insuredBy) {
+      const baseCost = this.info().cost(this._insuredBy);
+      if (baseCost > 0n) {
+        const num = BigInt(this.mg.config().structureInsuranceRefundNum());
+        const den = BigInt(this.mg.config().structureInsuranceRefundDen());
+        const refundAmount = (baseCost * num) / den;
+        this._insuredBy.addGold(refundAmount);
+        this.mg.displayMessage(
+          "messages.insurance_refund_conquest",
+          MessageType.INSURANCE_REFUND,
+          this._insuredBy.id(),
+          refundAmount,
+          { amount: refundAmount.toString() },
+        );
+      }
+    }
+
+    this._insuredBy = null;
     switch (this._type) {
       case UnitType.Warship:
       case UnitType.FighterJet:
@@ -233,6 +261,24 @@ export class UnitImpl implements Unit {
     if (!this.isActive()) {
       throw new Error(`cannot delete ${this} not active`);
     }
+
+    if (this._insuredBy) {
+      const baseCost = this.info().cost(this._insuredBy);
+      if (baseCost > 0n) {
+        const num = BigInt(this.mg.config().structureInsuranceRefundNum());
+        const den = BigInt(this.mg.config().structureInsuranceRefundDen());
+        const refundAmount = (baseCost * num) / den;
+        this._insuredBy.addGold(refundAmount);
+        this.mg.displayMessage(
+          "messages.insurance_refund",
+          MessageType.INSURANCE_REFUND,
+          this._insuredBy.id(),
+          refundAmount,
+          { amount: refundAmount.toString() },
+        );
+      }
+    }
+
     this._owner._units = this._owner._units.filter((b) => b !== this);
     this._active = false;
     this.mg.addUpdate(this.toUpdate());
@@ -407,5 +453,11 @@ export class UnitImpl implements Unit {
       this.mg.ticks() - this._lastSetSafeFromPirates <
       this.mg.config().safeFromPiratesCooldownMax()
     );
+  }
+
+  insure(player: Player): void {
+    if (isStructureType(this._type)) {
+      this._insuredBy = player;
+    }
   }
 }

--- a/tests/core/EconomyUpgrades.test.ts
+++ b/tests/core/EconomyUpgrades.test.ts
@@ -1,0 +1,131 @@
+import { PlayerExecution } from "../../src/core/execution/PlayerExecution";
+import { PlayerType, UnitType, UpgradeType } from "../../src/core/game/Game";
+import { GameImpl } from "../../src/core/game/GameImpl";
+import { PlayerImpl } from "../../src/core/game/PlayerImpl";
+import { playerInfo, setup } from "../util/Setup";
+
+describe("EconomyUpgrades", () => {
+  it("should increase max population by 25% with Urban Planning upgrade", async () => {
+    const player1Info = playerInfo("player1", PlayerType.Human);
+    const game = await setup("ocean_and_land", {}, [player1Info]);
+    const player = game.player("player1");
+
+    const initialMaxPopulation = game.config().maxPopulation(player);
+
+    player.addUpgrade(UpgradeType.UrbanPlanning);
+
+    const newMaxPopulation = game.config().maxPopulation(player);
+
+    expect(newMaxPopulation).toBe(Math.floor((initialMaxPopulation * 5) / 4));
+  });
+
+  it("should refund 33% of a structure's cost upon destruction with Structure Insurance upgrade", async () => {
+    const player1Info = playerInfo("player1", PlayerType.Human);
+    const game = await setup("ocean_and_land", { infiniteGold: true }, [
+      player1Info,
+    ]);
+    const player = game.player("player1");
+
+    player.addUpgrade(UpgradeType.StructureInsurance);
+
+    const cityCost = game.config().unitInfo(UnitType.City).cost(player);
+    const city = player.buildUnit(UnitType.City, game.ref(1, 1), {});
+
+    const initialGold = player.gold();
+
+    city.delete();
+
+    const finalGold = player.gold();
+    const expectedRefund = cityCost / 3n; // BigInt division
+
+    expect(finalGold).toBe(initialGold + expectedRefund);
+  });
+
+  it("should refund 33% of a structure's cost upon conquest", async () => {
+    const defenderInfo = playerInfo("defender", PlayerType.Human);
+    const attackerInfo = playerInfo("attacker", PlayerType.Human);
+    const game = (await setup("ocean_and_land", { infiniteGold: true }, [
+      defenderInfo,
+      attackerInfo,
+    ])) as GameImpl;
+    const defender = game.player("defender") as PlayerImpl;
+    const attacker = game.player("attacker") as PlayerImpl;
+
+    const defenderPlayerExecution = new PlayerExecution(defender);
+    defenderPlayerExecution.init(game, game.ticks());
+
+    const defenderTile = game.ref(0, 15);
+    game.conquer(defender, defenderTile);
+
+    defender.addUpgrade(UpgradeType.StructureInsurance);
+
+    const cityCost = game.config().unitInfo(UnitType.City).cost(defender);
+    const city = defender.buildUnit(UnitType.City, defenderTile, {});
+
+    const initialGold = defender.gold();
+
+    // Attacker conquers the tile, but not the unit yet
+    game.conquer(attacker, defenderTile);
+
+    // The defender's PlayerExecution will detect the ownership change and capture the unit
+    defenderPlayerExecution.tick(game.ticks());
+
+    const finalGold = defender.gold();
+    const expectedRefund = cityCost / 3n; // BigInt division
+
+    expect(city.owner()).toBe(attacker);
+    expect(finalGold).toBe(initialGold + expectedRefund);
+  });
+
+  it("should decrease troop regeneration by 20% with Automation upgrade", async () => {
+    const player1Info = playerInfo("player1", PlayerType.Human);
+    const game = await setup("ocean_and_land", {}, [player1Info]);
+    const player = game.player("player1");
+
+    const initialRegenRate = game.config().populationIncreaseRate(player);
+
+    player.addUpgrade(UpgradeType.Automation);
+
+    const newRegenRate = game.config().populationIncreaseRate(player);
+
+    // Use toBeCloseTo for floating point comparisons
+    expect(newRegenRate).toBeCloseTo((initialRegenRate * 4) / 5);
+  });
+
+  it("should double internal trade income with Automation upgrade", async () => {
+    const player1Info = playerInfo("player1", PlayerType.Human);
+    const game = (await setup("ocean_and_land", { infiniteGold: true }, [
+      player1Info,
+    ])) as GameImpl;
+    const player = game.player("player1") as PlayerImpl;
+
+    player.addUpgrade(UpgradeType.Automation);
+
+    const cargoManager = (game as any).cargoManager;
+
+    const path = [game.ref(0, 0), game.ref(0, 1)];
+    game.conquer(player, path[0]);
+    game.conquer(player, path[1]);
+
+    const mockTruck = {
+      id: 0,
+      owner: player,
+      path: path,
+      progress: path.length - 1, // Arrives on next tick
+      position: [0, 0],
+    };
+
+    // Manually add the truck to the cargo manager
+    (cargoManager as any).trucks.set(mockTruck.id, mockTruck);
+
+    const initialGold = player.gold();
+
+    cargoManager.tick([]);
+
+    const finalGold = player.gold();
+    const normalGold = game.config().cargoTruckGold(path.length);
+    const expectedGold = normalGold * 2n; // Automation doubles it
+
+    expect(finalGold).toBe(initialGold + expectedGold);
+  });
+});

--- a/tests/core/execution/PurchaseUpgradeExecution.test.ts
+++ b/tests/core/execution/PurchaseUpgradeExecution.test.ts
@@ -1,5 +1,10 @@
 import { PurchaseUpgradeExecution } from "../../../src/core/execution/PurchaseUpgradeExecution";
-import { Gold, Player, UpgradeType } from "../../../src/core/game/Game";
+import {
+  Gold,
+  Player,
+  PlayerType,
+  UpgradeType,
+} from "../../../src/core/game/Game";
 import { GameImpl } from "../../../src/core/game/GameImpl";
 
 describe("PurchaseUpgradeExecution", () => {
@@ -13,6 +18,8 @@ describe("PurchaseUpgradeExecution", () => {
       addUpgrade: jest.fn(),
       removeUpgrade: jest.fn(),
       removeGold: jest.fn(),
+      type: jest.fn().mockReturnValue(PlayerType.Human), // Default to Human
+      units: jest.fn().mockReturnValue([]),
     } as unknown as jest.Mocked<Player>;
 
     mockGame = {
@@ -91,5 +98,26 @@ describe("PurchaseUpgradeExecution", () => {
     expect(mockGame.markPlayerNodesForReconnection).toHaveBeenCalledWith(
       mockPlayer,
     );
+  });
+
+  it("should grant economy upgrades to bots when they purchase Roads", () => {
+    mockPlayer.gold.mockReturnValue(1_000_000n as Gold);
+    mockPlayer.hasUpgrade.mockReturnValue(false);
+    mockPlayer.type.mockReturnValue(PlayerType.Bot); // Set player type to Bot for this test
+
+    const exec = new PurchaseUpgradeExecution(mockPlayer, UpgradeType.Roads);
+    exec.init(mockGame, 0);
+
+    // Check that the initial upgrade was added
+    expect(mockPlayer.addUpgrade).toHaveBeenCalledWith(UpgradeType.Roads);
+
+    // Check that the three economy upgrades were also granted
+    expect(mockPlayer.addUpgrade).toHaveBeenCalledWith(
+      UpgradeType.UrbanPlanning,
+    );
+    expect(mockPlayer.addUpgrade).toHaveBeenCalledWith(
+      UpgradeType.StructureInsurance,
+    );
+    expect(mockPlayer.addUpgrade).toHaveBeenCalledWith(UpgradeType.Automation);
   });
 });


### PR DESCRIPTION
## Description:

This pull request introduces a new **Economy** tab to the Research panel and implements three distinct upgrades designed to provide players with new strategic pathways for managing their nation's growth, resilience, and financial power.

### Detailed Feature Breakdown

This PR combines several commits to deliver the following features:

<img width="677" height="284" alt="image" src="https://github.com/user-attachments/assets/ac9946f4-1545-4d47-b504-511e94653836" />

#### 1. New Upgrade: Urban Planning
- **Effect:** Increases the player's maximum population capacity by 25%.
- **Strategic Use:** This upgrade is ideal for players who are geographically constrained or who wish to build a dense, powerful core territory without needing to constantly expand their borders.

#### 2. New Upgrade: Structure Insurance
- **Effect:** Provides a 33% gold refund for any self-built structure that is either destroyed by attacks or captured by an enemy.
- **Strategic Use:** Acts as a crucial economic safety net, mitigating the impact of losses and allowing players to recover more quickly after a devastating attack. The insurance applies retroactively to all existing structures upon purchase.
- 
<img width="289" height="280" alt="image" src="https://github.com/user-attachments/assets/65bc5d53-0d0f-4d0c-8e3d-c19a5fa4e948" />

#### 3. New Upgrade: Automation
- **Effect:** A high-risk, high-reward upgrade with a dual effect:
  - **Benefit:** Doubles (2x) the gold income generated from internal land trade (cargo trucks).
  - **Drawback:** Slows the player's troop regeneration rate by 20%.
- **Strategic Use:** This upgrade is perfect for players aiming for an economic victory or for those in a secure position where they can sacrifice military recovery speed for a significant financial advantage.
<img width="670" height="277" alt="image" src="https://github.com/user-attachments/assets/fdc0fc73-565b-4ca5-b272-ab4b74045865" />

#### 4. AI Integration
- **Balanced Progression:** To ensure bots remain competitive and the game difficulty scales appropriately, bots that purchase the "Roads" upgrade are now automatically granted all three new economy upgrades (Urban Planning, Structure Insurance, and Automation).

#### 5. Testing
- A new, robust test has been added to reliably verify the refund mechanism for the Structure Insurance upgrade, specifically for the scenario where a structure is lost due to conquest.

---

### Technical Implementation Details

- **Configuration (`Game.ts`, `DefaultConfig.ts`):
  - The `UpgradeType` enum has been updated with `UrbanPlanning`, `StructureInsurance`, and `Automation`.
  - The logic for all three upgrades is implemented in `DefaultConfig.ts` by conditionally checking if a player `hasUpgrade()`:
    - **Urban Planning:** The `maxPopulation` function now returns a 25% higher value.
    - **Automation (Penalty):** The `populationIncreaseRate` function returns a 20% lower value.

- **Structure Insurance (`UnitImpl.ts`, `PlayerImpl.ts`):
  - An `insuredBy` property was added to `UnitImpl` to track which player, if any, has insured a structure.
  - The core refund logic is triggered within the `delete()` and `setOwner()` methods of `UnitImpl`. This ensures that no matter how a unit is lost (direct attack, nuke, conquest), the refund is processed correctly.
  - A new `insure()` method on the `Unit` interface allows for retroactive insurance, which is called by the `PurchaseUpgradeExecution` to apply the benefit to all existing buildings when the upgrade is bought.
  - New message types and translation keys were added to notify players of insurance refunds.

- **Automation Trade Bonus (`CargoTruckExecution.ts`):
  - The gold calculation for land-based trade (cargo trucks) was updated to check for the `Automation` upgrade and apply a 2x multiplier to the gold generated upon a successful delivery.

- **AI Integration (`PurchaseUpgradeExecution.ts`):
  - The logic to grant economy upgrades to bots is centralized in `PurchaseUpgradeExecution.ts`. When a bot purchases `UpgradeType.Roads`, the execution now automatically grants the three new economy upgrades to that bot player.

- **Testing (`StructureInsurance.test.ts`):
  - The original, flaky test for the conquest scenario was removed.
  - A new, more reliable test was written that directly simulates tile conquest and unit capture via the `PlayerExecution` tick. This avoids the complexity of a full `AttackExecution` and provides a more deterministic and focused test of the refund logic.

---

### New Configurable Settings

All balancing values for the new upgrades are defined in `src/core/configuration/DefaultConfig.ts` and can be easily modified.

- **Urban Planning:**
  - `urbanPlanningPopulationBonusNum()`: 5
  - `urbanPlanningPopulationBonusDen()`: 4
  - *(Result: 5/4 = 25% population bonus)*

- **Structure Insurance:**
  - `structureInsuranceRefundNum()`: 1
  - `structureInsuranceRefundDen()`: 3
  - *(Result: 1/3 = 33% refund)*

- **Automation:**
  - `automationTradeIncomeMultiplierNum()`: 2
  - `automationTradeIncomeMultiplierDen()`: 1
  - *(Result: 2/1 = 2x trade income)*
  
  - `automationTroopRegenMultiplierNum()`: 4
  - `automationTroopRegenMultiplierDen()`: 5
  - *(Result: 4/5 = 20% troop regeneration penalty)*


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
