### PR TITLE
fix(research): Close research tree modal on Escape key press

### DIFF
--- a/src/client/ResearchTreeModal.ts
+++ b/src/client/ResearchTreeModal.ts
@@ -9,6 +9,7 @@ import {
   type TechNode,
 } from "../core/tech/ResearchTree";
 import "./components/baseComponents/Modal";
+import { CloseViewEvent } from "./InputHandler";
 import { SendResearchTreeSelectIntentEvent } from "./Transport";
 
 // Category and TechNode are imported from core so client stays in sync
@@ -52,14 +53,16 @@ export class ResearchTreeModal extends LitElement {
     requestAnimationFrame(() => this.updateLayout());
     // Start a light refresh loop to reflect game state (gold/upgrades) while open
     this.refreshTimer ??= window.setInterval(() => this.requestUpdate(), 500);
+    this.eventBus.on(CloseViewEvent, this.close);
   }
-  close() {
+  close = () => {
     this.modalEl?.close();
     if (this.refreshTimer !== null) {
       window.clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
-  }
+    this.eventBus.off(CloseViewEvent, this.close);
+  };
   show() {
     this.visible = true;
     this.open();


### PR DESCRIPTION
## Description:

This commit makes the research tree modal listen to the CloseViewEvent and close itself when the event is fired. This allows the user to close the modal by pressing the **Escape** key.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
