### PR TITLE
feat(tech-tree 2 ): integrate Scorched Earth research and activation loop

### DIFF
--- a/src/client/ResearchTreeModal.ts
+++ b/src/client/ResearchTreeModal.ts
@@ -2,16 +2,22 @@ import { LitElement, html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import flaskIcon from "../../proprietary/images/flask.png";
 import { EventBus } from "../core/EventBus";
-import { GameView } from "../core/game/GameView";
+import { UpgradeType } from "../core/game/Game";
+import { GameView, PlayerView } from "../core/game/GameView";
 import {
   getTechNodes,
   isTechAvailable as serverIsTechAvailable,
   type Category,
   type TechNode,
 } from "../core/tech/ResearchTree";
+import { RESEARCH_TECH_IDS } from "../core/tech/TechEffects";
 import "./components/baseComponents/Modal";
 import { CloseViewEvent } from "./InputHandler";
-import { SendResearchTreeSelectIntentEvent } from "./Transport";
+import {
+  SendPurchaseUpgradeIntentEvent,
+  SendResearchTreeSelectIntentEvent,
+} from "./Transport";
+import { renderNumber } from "./Utils";
 
 // Category and TechNode are imported from core so client stays in sync
 
@@ -103,6 +109,53 @@ export class ResearchTreeModal extends LitElement {
     // Clicking sets this as the current research priority (server handles distribution)
     this.eventBus.emit(new SendResearchTreeSelectIntentEvent(id));
     this.requestUpdate();
+  }
+
+  private onActivateScorchedEarth(event: Event): void {
+    event.stopPropagation();
+    event.preventDefault();
+    if (!this.game || !this.eventBus) return;
+    const me = this.game.myPlayer();
+    if (!me || this.game.inSpawnPhase()) return;
+    if (me.hasUpgrade?.(UpgradeType.ScorchedEarth)) return;
+    this.eventBus.emit(
+      new SendPurchaseUpgradeIntentEvent(UpgradeType.ScorchedEarth),
+    );
+  }
+
+  private renderScorchedEarthAction(
+    tech: TechNode,
+    me: PlayerView | null,
+    isResearched: boolean,
+  ) {
+    if (tech.id !== RESEARCH_TECH_IDS.SCORCHED_EARTH || !me || !isResearched) {
+      return "";
+    }
+    const config = this.game?.config?.();
+    if (!config) return "";
+    const { cost } = config.upgradeInfo(UpgradeType.ScorchedEarth);
+    const activationCost = cost(me);
+    const gold = me.gold();
+    const hasUpgrade = me.hasUpgrade(UpgradeType.ScorchedEarth);
+    const disabled =
+      hasUpgrade || this.game?.inSpawnPhase?.() || gold < activationCost;
+    const tooltip = hasUpgrade
+      ? "Scorched Earth already active."
+      : gold < activationCost
+        ? "Earn more gold to activate Scorched Earth."
+        : "Activate to raze your road network and reset Economy techs.";
+    return html`
+      <button
+        class="tech-action"
+        @click=${(ev: Event) => this.onActivateScorchedEarth(ev)}
+        ?disabled=${disabled}
+        title=${tooltip}
+      >
+        ${hasUpgrade
+          ? "Activated"
+          : `Activate (${renderNumber(activationCost)} gold)`}
+      </button>
+    `;
   }
 
   private renderLegend() {
@@ -516,6 +569,36 @@ export class ResearchTreeModal extends LitElement {
             color: #86efac; /* keep success green */
             text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
           }
+          .tech-wrapper {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            width: 160px;
+            flex: 0 0 auto;
+          }
+          .tech-action {
+            background: rgba(176, 80, 78, 0.18);
+            border: 1px solid rgba(176, 80, 78, 0.45);
+            border-radius: 6px;
+            color: #ffd1d1;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 6px 8px;
+            text-align: center;
+            cursor: pointer;
+            transition:
+              background 120ms ease,
+              border-color 120ms ease,
+              color 120ms ease;
+          }
+          .tech-action:hover:not([disabled]) {
+            background: rgba(176, 80, 78, 0.3);
+            border-color: rgba(176, 80, 78, 0.6);
+          }
+          .tech-action[disabled] {
+            opacity: 0.65;
+            cursor: not-allowed;
+          }
           /* Highlight prioritized tech with a subtle halo */
           .tech.priority {
             border-color: rgba(59, 130, 246, 0.9);
@@ -751,112 +834,123 @@ export class ResearchTreeModal extends LitElement {
                             ]
                               .filter(Boolean)
                               .join(" ");
+                            const action = this.renderScorchedEarthAction(
+                              tech,
+                              me ?? null,
+                              isResearched,
+                            );
                             return html`
-                              <button
-                                class=${classes}
-                                data-id=${tech.id}
-                                @click=${() => this.onTechClick(tech.id)}
-                                title=${""}
-                                ?disabled=${!clickable}
-                              >
-                                <div class="tooltip">
-                                  <div
-                                    style="font-weight:600;margin-bottom:4px;"
-                                  >
-                                    ${tech.name}
-                                  </div>
-                                  ${tech.description
-                                    ? html`<div
-                                        style="opacity:.9;margin-bottom:6px;"
-                                      >
-                                        ${tech.description}
-                                      </div>`
-                                    : ""}
-                                  ${(() => {
-                                    const meLocal = this.game?.myPlayer?.();
-                                    const b =
-                                      meLocal?.researchBeakers?.(tech.id) ?? 0;
-                                    const pct = Math.min(
-                                      100,
-                                      Math.floor((b / (tech.cost || 1)) * 100),
-                                    );
-                                    return html`<div
-                                      style="font-size:11px;opacity:.9;"
-                                    >
-                                      <div class="cost-inline" translate="no">
-                                        <span
-                                          >Cost:
-                                          ${tech.cost.toLocaleString()}</span
-                                        >
-                                        <img
-                                          src=${flaskIcon}
-                                          alt="research cost"
-                                        />
-                                      </div>
-                                      ${isResearched
-                                        ? html`<div>Status: Completed</div>`
-                                        : html`<div>
-                                            Progress: ${b.toLocaleString()} /
-                                            ${tech.cost.toLocaleString()}
-                                            (${pct}%)
-                                          </div>`}
-                                    </div>`;
-                                  })()}
-                                </div>
-                                <div
-                                  style="font-weight:600; margin-bottom:6px;"
+                              <div class="tech-wrapper">
+                                <button
+                                  class=${classes}
+                                  data-id=${tech.id}
+                                  @click=${() => this.onTechClick(tech.id)}
+                                  title=${""}
+                                  ?disabled=${!clickable}
                                 >
-                                  ${tech.name}
-                                </div>
-                                <div class="cost-inline" translate="no">
-                                  <span>${tech.cost.toLocaleString()}</span>
-                                  <img src=${flaskIcon} alt="research cost" />
-                                </div>
-                                ${!isResearched && me
-                                  ? (() => {
+                                  <div class="tooltip">
+                                    <div
+                                      style="font-weight:600;margin-bottom:4px;"
+                                    >
+                                      ${tech.name}
+                                    </div>
+                                    ${tech.description
+                                      ? html`<div
+                                          style="opacity:.9;margin-bottom:6px;"
+                                        >
+                                          ${tech.description}
+                                        </div>`
+                                      : ""}
+                                    ${(() => {
+                                      const meLocal = this.game?.myPlayer?.();
                                       const b =
-                                        me.researchBeakers?.(tech.id) ?? 0;
+                                        meLocal?.researchBeakers?.(tech.id) ??
+                                        0;
                                       const pct = Math.min(
                                         100,
                                         Math.floor(
                                           (b / (tech.cost || 1)) * 100,
                                         ),
                                       );
-                                      return b > 0
-                                        ? html`<div class="progress-track">
-                                            <div
-                                              class="progress-fill ${priority ===
-                                              tech.id
-                                                ? "priority"
-                                                : ""}"
-                                              style="width:${pct}%"
-                                            ></div>
-                                          </div>`
-                                        : "";
-                                    })()
-                                  : ""}
-                                <div>
-                                  ${tech.requiresAllOf?.length
-                                    ? html`<span class="pill pill-req"
-                                        >Requires:
-                                        ${tech.requiresAllOf.length}</span
-                                      >`
+                                      return html`<div
+                                        style="font-size:11px;opacity:.9;"
+                                      >
+                                        <div class="cost-inline" translate="no">
+                                          <span
+                                            >Cost:
+                                            ${tech.cost.toLocaleString()}</span
+                                          >
+                                          <img
+                                            src=${flaskIcon}
+                                            alt="research cost"
+                                          />
+                                        </div>
+                                        ${isResearched
+                                          ? html`<div>Status: Completed</div>`
+                                          : html`<div>
+                                              Progress: ${b.toLocaleString()} /
+                                              ${tech.cost.toLocaleString()}
+                                              (${pct}%)
+                                            </div>`}
+                                      </div>`;
+                                    })()}
+                                  </div>
+                                  <div
+                                    style="font-weight:600; margin-bottom:6px;"
+                                  >
+                                    ${tech.name}
+                                  </div>
+                                  <div class="cost-inline" translate="no">
+                                    <span>${tech.cost.toLocaleString()}</span>
+                                    <img src=${flaskIcon} alt="research cost" />
+                                  </div>
+                                  ${!isResearched && me
+                                    ? (() => {
+                                        const b =
+                                          me.researchBeakers?.(tech.id) ?? 0;
+                                        const pct = Math.min(
+                                          100,
+                                          Math.floor(
+                                            (b / (tech.cost || 1)) * 100,
+                                          ),
+                                        );
+                                        return b > 0
+                                          ? html`<div class="progress-track">
+                                              <div
+                                                class="progress-fill ${priority ===
+                                                tech.id
+                                                  ? "priority"
+                                                  : ""}"
+                                                style="width:${pct}%"
+                                              ></div>
+                                            </div>`
+                                          : "";
+                                      })()
                                     : ""}
-                                  ${tech.requiresOneOf?.length
-                                    ? html`<span class="pill pill-oneof"
-                                        >One of:
-                                        ${tech.requiresOneOf.length}</span
-                                      >`
-                                    : ""}
-                                  ${priority === tech.id && !isResearched
-                                    ? html`<span
-                                        class="pill"
-                                        style="background:rgba(59,130,246,0.18);color:#cfe3ff;border:1px solid rgba(59,130,246,0.45);"
-                                        >Priority</span
-                                      >`
-                                    : ""}
-                                </div>
-                              </button>
+                                  <div>
+                                    ${tech.requiresAllOf?.length
+                                      ? html`<span class="pill pill-req"
+                                          >Requires:
+                                          ${tech.requiresAllOf.length}</span
+                                        >`
+                                      : ""}
+                                    ${tech.requiresOneOf?.length
+                                      ? html`<span class="pill pill-oneof"
+                                          >One of:
+                                          ${tech.requiresOneOf.length}</span
+                                        >`
+                                      : ""}
+                                    ${priority === tech.id && !isResearched
+                                      ? html`<span
+                                          class="pill"
+                                          style="background:rgba(59,130,246,0.18);color:#cfe3ff;border:1px solid rgba(59,130,246,0.45);"
+                                          >Priority</span
+                                        >`
+                                      : ""}
+                                  </div>
+                                </button>
+                                ${action}
+                              </div>
                             `;
                           })}
                         </div>

--- a/src/core/execution/PurchaseUpgradeExecution.ts
+++ b/src/core/execution/PurchaseUpgradeExecution.ts
@@ -1,5 +1,6 @@
 import { Execution, Player, UpgradeType } from "../game/Game";
 import { GameImpl } from "../game/GameImpl";
+import { RESEARCH_TECH_IDS } from "../tech/TechEffects";
 
 export class PurchaseUpgradeExecution implements Execution {
   private mg: GameImpl;
@@ -39,6 +40,13 @@ export class PurchaseUpgradeExecution implements Execution {
       this._isActive = false;
       return;
     }
+    if (
+      this.upgrade === UpgradeType.ScorchedEarth &&
+      !this.player.hasResearchedTech(RESEARCH_TECH_IDS.SCORCHED_EARTH)
+    ) {
+      this._isActive = false;
+      return;
+    }
 
     const cost = this.mg.config().upgradeInfo(this.upgrade).cost(this.player);
     if (this.player.gold() >= cost) {
@@ -47,10 +55,14 @@ export class PurchaseUpgradeExecution implements Execution {
 
       if (this.upgrade === UpgradeType.ScorchedEarth) {
         this.mg.destroyPlayerRoads(this.player);
+        this.player.setRoadInvestmentRate(0);
         this.player.removeUpgrade(UpgradeType.Roads);
-        this.player.removeUpgrade(UpgradeType.ScorchedEarth);
+        this.player.removeUpgrade(UpgradeType.InternationalTrade);
+        this.player.removeResearchedTechsByCategory("Economy");
+        this.mg.markPlayerNodesForReconnection(this.player);
       } else if (this.upgrade === UpgradeType.Roads) {
         this.mg.markPlayerNodesForReconnection(this.player);
+        this.player.removeUpgrade(UpgradeType.ScorchedEarth);
       }
     }
     this._isActive = false;

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -1,5 +1,6 @@
 import { Config } from "../configuration/Config";
 import { AllPlayersStats, ClientID } from "../Schemas";
+import { Category } from "../tech/ResearchTree";
 import { GameMap, TileRef } from "./GameMap";
 import {
   GameUpdate,
@@ -595,6 +596,7 @@ export interface Player {
   // Research Tree (per-match standalone)
   hasResearchedTech(techId: string): boolean;
   addResearchedTech(techId: string): void;
+  removeResearchedTechsByCategory(category: Category): void;
 
   captureUnit(unit: Unit): void;
 

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -1,7 +1,11 @@
 import { renderNumber, renderTroops } from "../../client/Utils";
 import { PseudoRandom } from "../PseudoRandom";
 import { ClientID } from "../Schemas";
-import { applyTechCompletionEffects } from "../tech/TechEffects";
+import { Category, findTech } from "../tech/ResearchTree";
+import {
+  applyTechCompletionEffects,
+  revokeTechEffects,
+} from "../tech/TechEffects";
 import {
   assertNever,
   distSortUnit,
@@ -341,6 +345,46 @@ export class PlayerImpl implements Player {
 
     // Apply centralized side-effects upon research completion
     applyTechCompletionEffects(this, this.mg, techId);
+  }
+  removeResearchedTechsByCategory(category: Category): void {
+    const toRemove: string[] = [];
+    for (const techId of this._researchTreeTechs) {
+      const node = findTech(techId);
+      if (!node) {
+        console.warn(
+          `[PlayerImpl] Unable to revoke unknown tech id '${techId}' while removing category '${category}'.`,
+        );
+        continue;
+      }
+      if (node.category === category) {
+        toRemove.push(techId);
+      }
+    }
+
+    const progressToClear: string[] = [];
+    for (const [techId] of this._researchBeakers) {
+      const node = findTech(techId);
+      if (!node) continue;
+      if (node.category === category) {
+        progressToClear.push(techId);
+      }
+    }
+
+    if (toRemove.length === 0 && progressToClear.length === 0) return;
+    const priority = this._researchPriority;
+    const cleared = new Set([...toRemove, ...progressToClear]);
+
+    for (const techId of toRemove) {
+      this._researchTreeTechs.delete(techId);
+      revokeTechEffects(this, this.mg, techId);
+    }
+    for (const techId of progressToClear) {
+      this._researchBeakers.delete(techId);
+    }
+
+    if (priority && cleared.has(priority)) {
+      this._researchPriority = null;
+    }
   }
   hasResearchedTech(techId: string): boolean {
     return this._researchTreeTechs.has(techId);

--- a/src/core/tech/ResearchTree.ts
+++ b/src/core/tech/ResearchTree.ts
@@ -48,11 +48,13 @@ const baseLevels: TechNode[] = (() => {
 const extras: TechNode[] = [
   {
     id: "Land-2B",
-    name: getTechMeta("Land-2B", { strict: false })?.name ?? "Land Tech 2B",
+    name: getTechMeta("Land-2B", { strict: false })?.name ?? "Scorched Earth",
     category: "Land",
     level: 2,
     requiresAllOf: ["Land-1"],
-    description: getTechMeta("Land-2B", { strict: false })?.description,
+    description:
+      getTechMeta("Land-2B", { strict: false })?.description ??
+      "Unlocks the Scorched Earth decision, letting you raze roads and reset economic techs.",
     cost: costForLevel(2),
   },
   {

--- a/src/core/tech/TechEffects.ts
+++ b/src/core/tech/TechEffects.ts
@@ -4,6 +4,7 @@ import { Game, Player, UpgradeType } from "../game/Game";
 // Keep IDs aligned with ResearchTreeModal generation (e.g., "Land-1").
 export const RESEARCH_TECH_IDS = {
   WWII_LESSONS: "Land-1",
+  SCORCHED_EARTH: "Land-2B",
   POST_WAR_RECONSTRUCTION: "Economy-1",
   INTERNATIONAL_TRADE: "Economy-2",
 } as const;
@@ -24,6 +25,8 @@ export interface DefenseCasualtyModifiers {
 export type TechEffect = {
   // Runs once when the tech is completed
   onComplete?: (player: Player, game: Game) => void;
+  // Runs when the tech is revoked (e.g., via category reset)
+  onRevoke?: (player: Player, game: Game) => void;
   // Applied each time casualty modifiers are computed while defending
   defense?: (mods: DefenseCasualtyModifiers) => void;
   // Applied each time casualty modifiers are computed while attacking
@@ -63,6 +66,15 @@ export const TECHS: Readonly<Record<string, TechDefinition>> = Object.freeze({
           player.addUpgrade?.(UpgradeType.Roads);
           game.markPlayerNodesForReconnection?.(player);
         }
+        if (player.hasUpgrade?.(UpgradeType.ScorchedEarth)) {
+          player.removeUpgrade?.(UpgradeType.ScorchedEarth);
+        }
+      },
+      onRevoke: (player, game) => {
+        if (player.hasUpgrade?.(UpgradeType.Roads)) {
+          player.removeUpgrade?.(UpgradeType.Roads);
+          game.markPlayerNodesForReconnection?.(player);
+        }
       },
     },
   },
@@ -79,6 +91,19 @@ export const TECHS: Readonly<Record<string, TechDefinition>> = Object.freeze({
           game.markPlayerNodesForReconnection?.(player);
         }
       },
+      onRevoke: (player, game) => {
+        if (player.hasUpgrade?.(UpgradeType.InternationalTrade)) {
+          player.removeUpgrade?.(UpgradeType.InternationalTrade);
+          game.markPlayerNodesForReconnection?.(player);
+        }
+      },
+    },
+  },
+  [RESEARCH_TECH_IDS.SCORCHED_EARTH]: {
+    meta: {
+      name: "Scorched Earth",
+      description:
+        "Unleash a scorched earth campaign—raze your road network and reset economic research to deny enemy logistics.",
     },
   },
 });
@@ -143,6 +168,15 @@ export function applyTechCompletionEffects(
 ): void {
   const entry = TECHS[techId]?.effects;
   entry?.onComplete?.(player, game);
+}
+
+export function revokeTechEffects(
+  player: Player,
+  game: Game,
+  techId: string,
+): void {
+  const entry = TECHS[techId]?.effects;
+  entry?.onRevoke?.(player, game);
 }
 
 /**

--- a/tests/core/execution/PurchaseUpgradeExecution.test.ts
+++ b/tests/core/execution/PurchaseUpgradeExecution.test.ts
@@ -13,7 +13,11 @@ describe("PurchaseUpgradeExecution", () => {
       addUpgrade: jest.fn(),
       removeUpgrade: jest.fn(),
       removeGold: jest.fn(),
+      hasResearchedTech: jest.fn(),
+      removeResearchedTechsByCategory: jest.fn(),
+      setRoadInvestmentRate: jest.fn(),
     } as unknown as jest.Mocked<Player>;
+    (mockPlayer.hasResearchedTech as jest.Mock).mockReturnValue(true);
 
     mockGame = {
       config: jest.fn().mockReturnValue({
@@ -61,6 +65,21 @@ describe("PurchaseUpgradeExecution", () => {
     expect(mockPlayer.addUpgrade).not.toHaveBeenCalled();
   });
 
+  it("requires the Scorched Earth tech to be researched before activation", () => {
+    (mockPlayer.hasResearchedTech as jest.Mock).mockReturnValue(false);
+    mockPlayer.hasUpgrade.mockReturnValue(false);
+
+    const exec = new PurchaseUpgradeExecution(
+      mockPlayer,
+      UpgradeType.ScorchedEarth,
+    );
+    exec.init(mockGame, 0);
+
+    expect(mockPlayer.removeGold).not.toHaveBeenCalled();
+    expect(mockPlayer.addUpgrade).not.toHaveBeenCalled();
+    expect(mockGame.destroyPlayerRoads).not.toHaveBeenCalled();
+  });
+
   it("should handle the special case for purchasing ScorchedEarth", () => {
     mockPlayer.gold.mockReturnValue(3_000_000n as Gold);
     mockPlayer.hasUpgrade.mockReturnValue(false);
@@ -71,13 +90,24 @@ describe("PurchaseUpgradeExecution", () => {
     );
     exec.init(mockGame, 0);
 
+    expect(mockPlayer.removeGold).toHaveBeenCalledWith(3_000_000n);
     expect(mockPlayer.addUpgrade).toHaveBeenCalledWith(
       UpgradeType.ScorchedEarth,
     );
     expect(mockGame.destroyPlayerRoads).toHaveBeenCalledWith(mockPlayer);
+    expect(mockPlayer.setRoadInvestmentRate).toHaveBeenCalledWith(0);
     expect(mockPlayer.removeUpgrade).toHaveBeenCalledWith(UpgradeType.Roads);
     expect(mockPlayer.removeUpgrade).toHaveBeenCalledWith(
+      UpgradeType.InternationalTrade,
+    );
+    expect(mockPlayer.removeResearchedTechsByCategory).toHaveBeenCalledWith(
+      "Economy",
+    );
+    expect(mockPlayer.removeUpgrade).not.toHaveBeenCalledWith(
       UpgradeType.ScorchedEarth,
+    );
+    expect(mockGame.markPlayerNodesForReconnection).toHaveBeenCalledWith(
+      mockPlayer,
     );
   });
 
@@ -90,6 +120,9 @@ describe("PurchaseUpgradeExecution", () => {
 
     expect(mockGame.markPlayerNodesForReconnection).toHaveBeenCalledWith(
       mockPlayer,
+    );
+    expect(mockPlayer.removeUpgrade).toHaveBeenCalledWith(
+      UpgradeType.ScorchedEarth,
     );
   });
 });

--- a/tests/core/game/PlayerImpl.tech.test.ts
+++ b/tests/core/game/PlayerImpl.tech.test.ts
@@ -1,0 +1,38 @@
+import { PlayerType, UpgradeType } from "../../../src/core/game/Game";
+import { GameImpl } from "../../../src/core/game/GameImpl";
+import { PlayerImpl } from "../../../src/core/game/PlayerImpl";
+import { RESEARCH_TECH_IDS } from "../../../src/core/tech/TechEffects";
+import { playerInfo, setup } from "../../util/Setup";
+
+describe("PlayerImpl.removeResearchedTechsByCategory", () => {
+  it("revokes economy techs and clears associated progress", async () => {
+    const game = (await setup("ocean_and_land")) as GameImpl;
+    const info = playerInfo("Tester", PlayerType.Human);
+    game.addPlayer(info);
+    const player = game.player(info.id) as PlayerImpl;
+
+    player.addResearchedTech(RESEARCH_TECH_IDS.WWII_LESSONS);
+    player.addResearchedTech(RESEARCH_TECH_IDS.POST_WAR_RECONSTRUCTION);
+    player.addResearchedTech(RESEARCH_TECH_IDS.INTERNATIONAL_TRADE);
+    player.addResearchBeakers("Economy-3", 500, 1_000);
+    player.setResearchPriority("Economy-3");
+
+    expect(player.hasUpgrade(UpgradeType.Roads)).toBe(true);
+    expect(player.hasUpgrade(UpgradeType.InternationalTrade)).toBe(true);
+    expect(player.researchBeakers("Economy-3")).toBe(500);
+
+    player.removeResearchedTechsByCategory("Economy");
+
+    expect(player.hasResearchedTech(RESEARCH_TECH_IDS.WWII_LESSONS)).toBe(true);
+    expect(
+      player.hasResearchedTech(RESEARCH_TECH_IDS.POST_WAR_RECONSTRUCTION),
+    ).toBe(false);
+    expect(
+      player.hasResearchedTech(RESEARCH_TECH_IDS.INTERNATIONAL_TRADE),
+    ).toBe(false);
+    expect(player.hasUpgrade(UpgradeType.Roads)).toBe(false);
+    expect(player.hasUpgrade(UpgradeType.InternationalTrade)).toBe(false);
+    expect(player.researchBeakers("Economy-3")).toBe(0);
+    expect(player.researchPriority()).toBeNull();
+  });
+});

--- a/tests/core/tech/TechEffects.test.ts
+++ b/tests/core/tech/TechEffects.test.ts
@@ -1,0 +1,32 @@
+import { UpgradeType } from "../../../src/core/game/Game";
+import {
+  applyTechCompletionEffects,
+  RESEARCH_TECH_IDS,
+} from "../../../src/core/tech/TechEffects";
+
+describe("TechEffects", () => {
+  it("removes Scorched Earth upgrade when Post-War Reconstruction completes", () => {
+    const owned = new Set<UpgradeType>([UpgradeType.ScorchedEarth]);
+    const player = {
+      hasUpgrade: jest.fn((upgrade: UpgradeType) => owned.has(upgrade)),
+      addUpgrade: jest.fn((upgrade: UpgradeType) => owned.add(upgrade)),
+      removeUpgrade: jest.fn((upgrade: UpgradeType) => owned.delete(upgrade)),
+    } as any;
+    const game = {
+      markPlayerNodesForReconnection: jest.fn(),
+    } as any;
+
+    applyTechCompletionEffects(
+      player,
+      game,
+      RESEARCH_TECH_IDS.POST_WAR_RECONSTRUCTION,
+    );
+
+    expect(player.addUpgrade).toHaveBeenCalledWith(UpgradeType.Roads);
+    expect(game.markPlayerNodesForReconnection).toHaveBeenCalledWith(player);
+    expect(player.removeUpgrade).toHaveBeenCalledWith(
+      UpgradeType.ScorchedEarth,
+    );
+    expect(owned.has(UpgradeType.ScorchedEarth)).toBe(false);
+  });
+});

--- a/tests/integrations/ScorchedEarth.test.ts
+++ b/tests/integrations/ScorchedEarth.test.ts
@@ -2,6 +2,7 @@ import { PurchaseUpgradeExecution } from "../../src/core/execution/PurchaseUpgra
 import { PlayerType, UnitType, UpgradeType } from "../../src/core/game/Game";
 import { GameImpl } from "../../src/core/game/GameImpl";
 import { PlayerImpl } from "../../src/core/game/PlayerImpl";
+import { RESEARCH_TECH_IDS } from "../../src/core/tech/TechEffects";
 import { playerInfo, setup } from "../util/Setup";
 
 describe("Scorched Earth Full Cycle Integration Test", () => {
@@ -28,26 +29,45 @@ describe("Scorched Earth Full Cycle Integration Test", () => {
       }
     }
 
-    // Step 1: Buy Roads and verify network creation
-    game.addExecution(new PurchaseUpgradeExecution(player, UpgradeType.Roads));
+    // Research core economy techs to unlock and test revocation behavior
+    player.addResearchedTech(RESEARCH_TECH_IDS.WWII_LESSONS);
+    player.addResearchedTech(RESEARCH_TECH_IDS.POST_WAR_RECONSTRUCTION);
+    player.addResearchedTech(RESEARCH_TECH_IDS.INTERNATIONAL_TRADE);
+
+    // Allow the automatic road upgrade to build out the network
     for (let i = 0; i < 200; i++) {
       game.executeNextTick();
     }
     expect(game.roads().length).toBeGreaterThan(0);
+    expect(player.hasUpgrade(UpgradeType.Roads)).toBe(true);
+    expect(player.hasUpgrade(UpgradeType.InternationalTrade)).toBe(true);
 
-    // Step 2: Buy Scorched Earth and verify network destruction
+    // Step 2: Research and activate Scorched Earth, verify network destruction and tech rollback
+    player.addResearchedTech(RESEARCH_TECH_IDS.SCORCHED_EARTH);
     game.addExecution(
       new PurchaseUpgradeExecution(player, UpgradeType.ScorchedEarth),
     );
     game.executeNextTick();
     expect(game.roads().length).toBe(0);
     expect(player.hasUpgrade(UpgradeType.Roads)).toBe(false);
+    expect(player.hasUpgrade(UpgradeType.InternationalTrade)).toBe(false);
+    expect(player.hasUpgrade(UpgradeType.ScorchedEarth)).toBe(true);
+    expect(player.roadInvestmentRate()).toBe(0);
+    expect(
+      player.hasResearchedTech(RESEARCH_TECH_IDS.POST_WAR_RECONSTRUCTION),
+    ).toBe(false);
+    expect(
+      player.hasResearchedTech(RESEARCH_TECH_IDS.INTERNATIONAL_TRADE),
+    ).toBe(false);
 
-    // Step 3: Re-buy Roads and verify network reformation
-    game.addExecution(new PurchaseUpgradeExecution(player, UpgradeType.Roads));
+    // Step 3: Re-unlock roads and verify Scorched Earth deactivates
+    player.addResearchedTech(RESEARCH_TECH_IDS.POST_WAR_RECONSTRUCTION);
+    expect(player.hasUpgrade(UpgradeType.ScorchedEarth)).toBe(false);
+    player.setRoadInvestmentRate(1);
     for (let i = 0; i < 200; i++) {
       game.executeNextTick();
     }
     expect(game.roads().length).toBeGreaterThan(0);
+    expect(player.hasUpgrade(UpgradeType.ScorchedEarth)).toBe(false);
   });
 });


### PR DESCRIPTION
## Description:
- wire `SCORCHED_EARTH` into the research tree metadata, add on-complete/on-revoke handlers for economy techs, and introduce a reusable `revokeTechEffects` helper.
- extend `Player`/`PlayerImpl` with `removeResearchedTechsByCategory`, ensuring economy tech resets clear beakers, research priority, and previously granted upgrades.
- gate `PurchaseUpgradeExecution` on the tech unlock, centralize all Scorched Earth activation effects (road destruction, investment reset, upgrade removal, category rollback), and make Roads re-purchase drop the Scorched Earth upgrade.
- add a client-side “Activate Scorched Earth” button in the research modal that sends the purchase intent with gold gating and warning copy.
- expand unit/integration coverage to include execution gating, category reset behavior, tech revoke effects, and the full build → scorch → rebuild loop.

### Tests
- npm test -- TechEffects
- npm test -- PurchaseUpgradeExecution
- npm test -- PlayerImpl.tech
- npm test -- ScorchedEarth

![chrome_cJ84EIaSG2](https://github.com/user-attachments/assets/d333f579-fb91-47ca-b27d-db4562f48aec)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
