### PR TITLE
Starting gold selector in singleplayer and custom lobby v0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@opentelemetry/sdk-metrics": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.32.0",
         "@opentelemetry/winston-transport": "^0.11.0",
+        "@types/twemoji": "^13.1.1",
         "colord": "^2.9.3",
         "colorjs.io": "^0.5.2",
         "dompurify": "^3.1.7",
@@ -7424,6 +7425,15 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/twemoji": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@types/twemoji/-/twemoji-13.1.1.tgz",
+      "integrity": "sha512-0qnUqLhaSSGsvLXiwWnmcuOza9oGnGwXpxXauB6rEHsU30Dfmvizzwx2TzwUjlsY4ox+39tdG89CpJ/i3J/Cvw==",
+      "license": "MIT",
+      "dependencies": {
+        "twemoji": "*"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@opentelemetry/sdk-metrics": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.32.0",
     "@opentelemetry/winston-transport": "^0.11.0",
+    "@types/twemoji": "^13.1.1",
     "colord": "^2.9.3",
     "colorjs.io": "^0.5.2",
     "dompurify": "^3.1.7",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -167,6 +167,11 @@
     "regional": "Regional",
     "fantasy": "Other"
   },
+  "starting_gold": {
+    "label": "Starting gold",
+    "default": "0 (default)",
+    "millions": "{amount}M"
+  },
   "private_lobby": {
     "title": "Join Private Lobby",
     "enter_id": "Enter Lobby ID",

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import randomMap from "../../resources/images/RandomMap.webp";
-import { translateText } from "../client/Utils";
+import { formatStartingGold, translateText } from "../client/Utils";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import {
   Difficulty,
@@ -15,9 +15,11 @@ import {
 } from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import {
+  ClientInfo,
   GameConfig,
   GameInfo,
   PeaceTimerDuration,
+  StartingGoldValues,
   TeamCountConfig,
 } from "../core/Schemas";
 import { generateID } from "../core/Util";
@@ -27,6 +29,11 @@ import { DifficultyDescription } from "./components/Difficulties";
 import "./components/Maps";
 import { JoinLobbyEvent } from "./Main";
 import { renderUnitTypeOptions } from "./utilities/RenderUnitTypeOptions";
+
+type StartingGoldOption = (typeof StartingGoldValues)[number];
+const startingGoldList = [...StartingGoldValues] as number[];
+const isStartingGoldOption = (value: number): value is StartingGoldOption =>
+  startingGoldList.includes(value);
 
 @customElement("host-lobby-modal")
 export class HostLobbyModal extends LitElement {
@@ -45,12 +52,13 @@ export class HostLobbyModal extends LitElement {
   @state() private instantBuild: boolean = false;
   @state() private lobbyId = "";
   @state() private copySuccess = false;
-  @state() private players: string[] = [];
+  @state() private clients: ClientInfo[] = [];
   @state() private useRandomMap: boolean = false;
   @state() private disabledUnits: UnitType[] = [];
   @state() private lobbyIdVisible: boolean = true;
   @state() private selectedPeaceTimerDuration: PeaceTimerDuration =
     PeaceTimerDuration.None;
+  @state() private startingGold: StartingGoldOption = StartingGoldValues[0];
 
   private playersInterval: NodeJS.Timeout | null = null;
   // Add a new timer for debouncing bot changes
@@ -378,6 +386,26 @@ export class HostLobbyModal extends LitElement {
                   </div>
                 </label>
 
+                <label for="starting-gold" class="option-card">
+                  <div class="option-card-title">
+                    ${translateText("starting_gold.label")}
+                  </div>
+                  <select
+                    id="starting-gold"
+                    class="peace-timer-select"
+                    @change=${this.handleStartingGoldChange}
+                    .value="${String(this.startingGold)}"
+                  >
+                    ${StartingGoldValues.map(
+                      (value) => html`
+                        <option value="${value}">
+                          ${formatStartingGold(value)}
+                        </option>
+                      `,
+                    )}
+                </select>
+                </label>
+
                 <label for="peace-timer" class="option-card">
                   <div class="option-card-title">
                     ${translateText("host_modal.peace_timer")}
@@ -429,17 +457,18 @@ export class HostLobbyModal extends LitElement {
         <!-- Lobby Selection -->
         <div class="options-section">
           <div class="option-title">
-            ${this.players.length}
+            ${this.clients.length}
             ${
-              this.players.length === 1
+              this.clients.length === 1
                 ? translateText("host_modal.player")
                 : translateText("host_modal.players")
             }
           </div>
 
           <div class="players-list">
-            ${this.players.map(
-              (player) => html`<span class="player-tag">${player}</span>`,
+            ${this.clients.map(
+              (client) =>
+                html`<span class="player-tag">${client.username}</span>`,
             )}
           </div>
         </div>
@@ -447,11 +476,11 @@ export class HostLobbyModal extends LitElement {
         <div class="start-game-button-container">
           <button
             @click=${this.startGame}
-            ?disabled=${this.players.length < 2}
+            ?disabled=${this.clients.length < 2}
             class="start-game-button"
           >
             ${
-              this.players.length === 1
+              this.clients.length === 1
                 ? translateText("host_modal.waiting")
                 : translateText("host_modal.start")
             }
@@ -476,6 +505,11 @@ export class HostLobbyModal extends LitElement {
     createLobby()
       .then((lobby) => {
         this.lobbyId = lobby.gameID;
+        if (lobby.gameConfig?.startingGold !== undefined) {
+          this.startingGold = lobby.gameConfig.startingGold;
+        } else {
+          this.startingGold = 0;
+        }
         // join lobby
       })
       .then(() => {
@@ -561,6 +595,15 @@ export class HostLobbyModal extends LitElement {
     this.putGameConfig();
   }
 
+  private handleStartingGoldChange(e: Event) {
+    const value = parseInt((e.target as HTMLSelectElement).value, 10);
+    if (isNaN(value) || !isStartingGoldOption(value)) {
+      return;
+    }
+    this.startingGold = value;
+    this.putGameConfig();
+  }
+
   private handlePeaceTimerChange(e: Event) {
     this.selectedPeaceTimerDuration = parseInt(
       (e.target as HTMLSelectElement).value,
@@ -605,6 +648,7 @@ export class HostLobbyModal extends LitElement {
           disabledUnits: this.disabledUnits,
           playerTeams: this.teamCount,
           peaceTimerDurationMinutes: this.selectedPeaceTimerDuration,
+          startingGold: this.startingGold,
         } satisfies Partial<GameConfig>),
       },
     );
@@ -675,7 +719,10 @@ export class HostLobbyModal extends LitElement {
       .then((response) => response.json())
       .then((data: GameInfo) => {
         console.log(`got game info response: ${JSON.stringify(data)}`);
-        this.players = data.clients?.map((p) => p.username) ?? [];
+        this.clients = data.clients ?? [];
+        if (data.gameConfig?.startingGold !== undefined) {
+          this.startingGold = data.gameConfig.startingGold;
+        }
       });
   }
 }

--- a/src/client/JoinPrivateLobbyModal.ts
+++ b/src/client/JoinPrivateLobbyModal.ts
@@ -17,6 +17,7 @@ export class JoinPrivateLobbyModal extends LitElement {
   @state() private message: string = "";
   @state() private hasJoined = false;
   @state() private players: string[] = [];
+  @state() private startingGold: number | null = null;
 
   private playersInterval: NodeJS.Timeout | null = null;
 
@@ -103,6 +104,7 @@ export class JoinPrivateLobbyModal extends LitElement {
       clearInterval(this.playersInterval);
       this.playersInterval = null;
     }
+    this.startingGold = null;
   }
 
   public closeAndLeave() {
@@ -263,6 +265,7 @@ export class JoinPrivateLobbyModal extends LitElement {
       .then((response) => response.json())
       .then((data: GameInfo) => {
         this.players = data.clients?.map((p) => p.username) ?? [];
+        this.startingGold = data.gameConfig?.startingGold ?? 0;
       })
       .catch((error) => {
         console.error("Error polling players:", error);

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import randomMap from "../../resources/images/RandomMap.webp";
-import { translateText } from "../client/Utils";
+import { formatStartingGold, translateText } from "../client/Utils";
 import {
   Difficulty,
   Duos,
@@ -13,7 +13,11 @@ import {
   UnitType,
   mapCategories,
 } from "../core/game/Game";
-import { PeaceTimerDuration, TeamCountConfig } from "../core/Schemas";
+import {
+  PeaceTimerDuration,
+  StartingGoldValues,
+  TeamCountConfig,
+} from "../core/Schemas";
 import { generateID } from "../core/Util";
 import "./components/baseComponents/Button";
 import "./components/baseComponents/Modal";
@@ -24,6 +28,11 @@ import { FlagInput } from "./FlagInput";
 import { JoinLobbyEvent } from "./Main";
 import { UsernameInput } from "./UsernameInput";
 import { renderUnitTypeOptions } from "./utilities/RenderUnitTypeOptions";
+
+type StartingGoldOption = (typeof StartingGoldValues)[number];
+const startingGoldList = [...StartingGoldValues] as number[];
+const isStartingGoldOption = (value: number): value is StartingGoldOption =>
+  startingGoldList.includes(value);
 
 @customElement("single-player-modal")
 export class SinglePlayerModal extends LitElement {
@@ -43,6 +52,7 @@ export class SinglePlayerModal extends LitElement {
   @state() private teamCount: TeamCountConfig = 2;
   @state() private selectedPeaceTimerDuration: PeaceTimerDuration =
     PeaceTimerDuration.None;
+  @state() private startingGold: StartingGoldOption = StartingGoldValues[0];
 
   @state() private disabledUnits: UnitType[] = [];
 
@@ -283,6 +293,26 @@ export class SinglePlayerModal extends LitElement {
                 </div>
               </label>
 
+              <label for="starting-gold" class="option-card">
+                <div class="option-card-title">
+                  ${translateText("starting_gold.label")}
+                </div>
+                <select
+                  id="starting-gold"
+                  class="peace-timer-select"
+                  @change=${this.handleStartingGoldChange}
+                  .value="${String(this.startingGold)}"
+                >
+                  ${StartingGoldValues.map(
+                    (value) => html`
+                      <option value="${value}">
+                        ${formatStartingGold(value)}
+                      </option>
+                    `,
+                  )}
+                </select>
+              </label>
+
               <label for="peace-timer" class="option-card">
                 <div class="option-card-title">
                   ${translateText("host_modal.peace_timer")}
@@ -345,6 +375,7 @@ export class SinglePlayerModal extends LitElement {
   public open() {
     this.modalEl?.open();
     this.useRandomMap = false;
+    this.startingGold = 0;
   }
 
   public close() {
@@ -382,6 +413,14 @@ export class SinglePlayerModal extends LitElement {
 
   private handleInfiniteTroopsChange(e: Event) {
     this.infiniteTroops = Boolean((e.target as HTMLInputElement).checked);
+  }
+
+  private handleStartingGoldChange(e: Event) {
+    const value = parseInt((e.target as HTMLSelectElement).value, 10);
+    if (isNaN(value) || !isStartingGoldOption(value)) {
+      return;
+    }
+    this.startingGold = value;
   }
 
   private handlePeaceTimerChange(e: Event) {
@@ -470,6 +509,7 @@ export class SinglePlayerModal extends LitElement {
                 .map((u) => Object.values(UnitType).find((ut) => ut === u))
                 .filter((ut): ut is UnitType => ut !== undefined),
               peaceTimerDurationMinutes: this.selectedPeaceTimerDuration,
+              startingGold: this.startingGold,
             },
           },
         } satisfies JoinLobbyEvent,

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -97,6 +97,14 @@ export const translateText = (
   return langSelector.translateText(key, params);
 };
 
+export function formatStartingGold(value: number): string {
+  if (value === 0) {
+    return translateText("starting_gold.default");
+  }
+  const millions = String(Math.trunc(value / 1_000_000));
+  return translateText("starting_gold.millions", { amount: millions });
+}
+
 /**
  * Severity colors mapping for message types
  */

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -20,6 +20,11 @@ import { flattenedEmojiTable } from "./Util";
 export type GameID = string;
 export type ClientID = string;
 
+export const StartingGoldValues = [
+  0, 1_000_000, 2_000_000, 3_000_000, 4_000_000, 5_000_000, 10_000_000,
+  15_000_000, 20_000_000, 25_000_000, 35_000_000, 50_000_000,
+] as const;
+
 export type Intent =
   | SpawnIntent
   | AttackIntent
@@ -172,6 +177,9 @@ export const GameConfigSchema = z.object({
   peaceTimerDurationMinutes: z
     .nativeEnum(PeaceTimerDuration)
     .default(PeaceTimerDuration.None),
+  startingGold: z
+    .union(StartingGoldValues.map((value) => z.literal(value)))
+    .default(0),
 });
 
 export const TeamSchema = z.string();

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -84,6 +84,7 @@ export interface Config {
   infiniteGold(): boolean;
   infiniteTroops(): boolean;
   instantBuild(): boolean;
+  startingGold(): number;
   numSpawnPhaseTurns(): number;
   userSettings(): UserSettings;
   playerTeams(): TeamCountConfig;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -321,6 +321,9 @@ export class DefaultConfig implements Config {
   infiniteTroops(): boolean {
     return this._gameConfig.infiniteTroops;
   }
+  startingGold(): number {
+    return this._gameConfig.startingGold ?? 0;
+  }
   tradeShipGold(dist: number): Gold {
     return BigInt(Math.floor(10000 + 150 * Math.pow(dist, 1.1)));
   }

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -462,6 +462,10 @@ export class GameImpl implements Game {
     this._playersBySmallID.push(player);
     this.nextPlayerID++;
     this._players.set(playerInfo.id, player);
+    const startingGold = this.config().startingGold();
+    if (startingGold > 0 && playerInfo.playerType === PlayerType.Human) {
+      player.addGold(BigInt(startingGold));
+    }
     return player;
   }
 

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -28,22 +28,34 @@ export class GameManager {
     return false;
   }
 
-  createGame(id: GameID, gameConfig: GameConfig | undefined) {
-    const game = new GameServer(id, this.log, Date.now(), this.config, {
-      gameMap: GameMapType.World,
-      gameType: GameType.Private,
-      difficulty: Difficulty.Medium,
-      disableNPCs: false,
-      infiniteGold: false,
-      infiniteTroops: false,
-      instantBuild: false,
-      gameMode: GameMode.FFA,
-      bots: 400,
-      disabledUnits: [],
-      peaceTimerDurationMinutes:
-        gameConfig?.peaceTimerDurationMinutes ?? PeaceTimerDuration.None,
-      ...gameConfig,
-    });
+  createGame(
+    id: GameID,
+    gameConfig: GameConfig | undefined,
+    creatorClientID?: string,
+  ) {
+    const game = new GameServer(
+      id,
+      this.log,
+      Date.now(),
+      this.config,
+      {
+        gameMap: GameMapType.World,
+        gameType: GameType.Private,
+        difficulty: Difficulty.Medium,
+        disableNPCs: false,
+        infiniteGold: false,
+        infiniteTroops: false,
+        instantBuild: false,
+        gameMode: GameMode.FFA,
+        bots: 400,
+        disabledUnits: [],
+        peaceTimerDurationMinutes:
+          gameConfig?.peaceTimerDurationMinutes ?? PeaceTimerDuration.None,
+        startingGold: 0,
+        ...gameConfig,
+      },
+      creatorClientID,
+    );
     this.games.set(id, game);
     return game;
   }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -64,14 +64,18 @@ export class GameServer {
 
   private websockets: Set<WebSocket> = new Set();
 
+  private LobbyCreatorID: string | undefined;
+
   constructor(
     public readonly id: string,
     readonly log_: Logger,
     public readonly createdAt: number,
     private config: ServerConfig,
     public gameConfig: GameConfig,
+    lobbyCreatorID?: string,
   ) {
     this.log = log_.child({ gameID: id });
+    this.LobbyCreatorID = lobbyCreatorID ?? undefined;
   }
 
   public updateGameConfig(gameConfig: Partial<GameConfig>): void {
@@ -111,6 +115,9 @@ export class GameServer {
     if (gameConfig.peaceTimerDurationMinutes !== undefined) {
       this.gameConfig.peaceTimerDurationMinutes =
         gameConfig.peaceTimerDurationMinutes;
+    }
+    if (gameConfig.startingGold !== undefined) {
+      this.gameConfig.startingGold = gameConfig.startingGold;
     }
   }
 

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -88,6 +88,7 @@ export class MapPlaylist {
       playerTeams,
       bots: 400,
       peaceTimerDurationMinutes: PeaceTimerDuration.None,
+      startingGold: 0,
     } satisfies GameConfig;
   }
 

--- a/tests/core/GameConfigSchema.test.ts
+++ b/tests/core/GameConfigSchema.test.ts
@@ -1,0 +1,52 @@
+import {
+  GameConfigSchema,
+  PeaceTimerDuration,
+  StartingGoldValues,
+} from "../../src/core/Schemas";
+import {
+  Difficulty,
+  GameMapType,
+  GameMode,
+  GameType,
+} from "../../src/core/game/Game";
+
+const baseConfig = {
+  gameMap: GameMapType.World,
+  difficulty: Difficulty.Medium,
+  gameType: GameType.Singleplayer,
+  gameMode: GameMode.FFA,
+  disableNPCs: false,
+  bots: 0,
+  infiniteGold: false,
+  infiniteTroops: false,
+  instantBuild: false,
+  peaceTimerDurationMinutes: PeaceTimerDuration.None,
+};
+
+describe("GameConfigSchema startingGold validation", () => {
+  it("accepts approved starting gold values", () => {
+    for (const value of StartingGoldValues) {
+      const result = GameConfigSchema.safeParse({
+        ...baseConfig,
+        startingGold: value,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.startingGold).toBe(value);
+      }
+    }
+  });
+
+  it("defaults startingGold to zero when omitted", () => {
+    const result = GameConfigSchema.parse(baseConfig);
+    expect(result.startingGold).toBe(0);
+  });
+
+  it("rejects arbitrary starting gold values", () => {
+    const result = GameConfigSchema.safeParse({
+      ...baseConfig,
+      startingGold: 123456,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/core/game/GameImpl.test.ts
+++ b/tests/core/game/GameImpl.test.ts
@@ -121,3 +121,34 @@ describe("GameImpl", () => {
     expect(attacker.isTraitor()).toBe(true);
   });
 });
+
+describe("Starting gold distribution", () => {
+  test("applies starting gold only to human players", async () => {
+    const startingGold = 5_000_000;
+    const humanInfo = new PlayerInfo(
+      "fr",
+      "human-player",
+      PlayerType.Human,
+      "client-human",
+      "human-id",
+    );
+
+    const gameWithStartingGold = await setup(
+      "ocean_and_land",
+      { startingGold },
+      [humanInfo],
+    );
+    const humanPlayer = gameWithStartingGold.player(humanInfo.id);
+    expect(humanPlayer.gold()).toBe(BigInt(startingGold));
+
+    const botInfo = new PlayerInfo(
+      "fr",
+      "bot-player",
+      PlayerType.Bot,
+      null,
+      "bot-id",
+    );
+    const botPlayer = gameWithStartingGold.addPlayer(botInfo);
+    expect(botPlayer.gold()).toBe(0n);
+  });
+});

--- a/tests/util/Setup.ts
+++ b/tests/util/Setup.ts
@@ -47,6 +47,7 @@ export async function setup(
     infiniteTroops: false,
     instantBuild: false,
     peaceTimerDurationMinutes: PeaceTimerDuration.None,
+    startingGold: 0,
     ..._gameConfig,
   };
   const config = new TestConfig(


### PR DESCRIPTION
## Description:
- Introduced curated starting-gold presets for single-player and custom lobbies, keeping ranked/public modes untouched.
- Added UI controls so hosts and solo players can pick a preset; default remains zero gold.
- Ensured only human players receive the configured starting gold to avoid AI purchasing spikes.
- Hardened server validation/config plumbing and backfilled Jest tests for schema and gameplay.

<img width="134" height="372" alt="image" src="https://github.com/user-attachments/assets/1b245f91-4c8a-4c19-a702-b197a702d82b" />

## New Starting Gold Option
1. **Single Player Setup**
   - Open the single-player modal.
   - Locate the `Starting gold` dropdown in the options column.
   - Choose one of: `0 (default)`, `1M`, `2M`, `3M`, `4M`, `5M`, `10M`, `15M`, `20M`, `25M`, `35M`, `50M`.
   - The selection applies when you press **Start Game** and resets when the modal closes.

2. **Custom Lobby Host (private/custom lobbies)**
   - Open **Host Lobby** and create a lobby.
   - Use the same `Starting gold` dropdown in the options list.
   - Guests see the chosen preset via lobby polling; confirm it before pressing **Start Game**.
   - The choice is session-scoped; adjust it prior to starting the match if needed.

3. **Join Private Lobby**
   - When joining an existing custom lobby, the Join Private Lobby modal now surfaces the lobby’s starting-gold amount so you know what to expect.

### Restrictions
- Ranked/public lobbies do **not** expose or honor this selector.
- Starting gold is granted to human players only; AI/bots always begin at zero.

## Technical Notes
### Schema & Validation
- Added `StartingGoldValues` in `src/core/Schemas.ts` and enforced it through the `GameConfigSchema` literal union.
- `CreateGameInputSchema` / `GameInputSchema` inherit the same constraint, so arbitrary numbers are rejected during lobby creation or updates.

### Configuration Pipeline
- `Config` interface gains a `startingGold()` accessor; implementations return zero when the field is omitted.
- Default seeds (`GameManager.createGame`, `MapPlaylist.gameConfig`) and lobby updates (`GameServer.updateGameConfig`) now carry `startingGold: 0` by default.

### Gameplay
- `GameImpl.addPlayer` applies the configured starting gold only when `playerInfo.playerType === PlayerType.Human`.
- Bots and fake humans stay at `0n`, preventing the performance hit from mass purchases.

### Client UI Integration
- `SinglePlayerModal`, `HostLobbyModal`, and `JoinPrivateLobbyModal` maintain `startingGold` state with literal-type guards.
- Dropdowns render the curated presets via `formatStartingGold` in `src/client/Utils.ts`.
- Serialized payloads (join events, `putGameConfig` requests) carry the selected value; public lobby cards were intentionally left unchanged.

### Internationalization
- `resources/lang/en.json` now includes `starting_gold.label`, `starting_gold.default`, and `starting_gold.millions`, which all selectors reuse.

### Tests
- `tests/core/GameConfigSchema.test.ts` ensures approved values pass, missing values default to zero, and invalid numbers fail validation.
- `tests/core/game/GameImpl.test.ts` adds a scenario verifying only human players receive starting gold.
- `npm test` covers the new suites (existing tech warnings remain but no failures).


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
