### PR TITLE
Research Tree UI Overhaul and Enhancements

### DIFF
--- a/src/client/ResearchTreeModal.ts
+++ b/src/client/ResearchTreeModal.ts
@@ -26,7 +26,7 @@ import {
 } from "./Transport";
 import { renderNumber } from "./Utils";
 
-type ResearchTab = Category | "All";
+type ResearchTab = Category | "Overview";
 
 // Category and TechNode are imported from core so client stays in sync
 
@@ -55,7 +55,7 @@ export class ResearchTreeModal extends LitElement {
     "Air",
     "Nuclear",
     "Economy",
-    "All",
+    "Overview",
   ];
 
   @state()
@@ -228,15 +228,16 @@ export class ResearchTreeModal extends LitElement {
   private getOrderedTabs(): ResearchTab[] {
     const available = new Set(this.categories);
     const ordered = this.tabOrder.filter((cat) => {
-      if (cat === "All") return true;
+      if (cat === "Overview") return true;
       return available.has(cat);
     });
-    if (!ordered.includes("All") && available.size > 0) ordered.push("All");
+    if (!ordered.includes("Overview") && available.size > 0)
+      ordered.push("Overview");
     return ordered.length ? ordered : [...available];
   }
 
   private getActiveCategory(): Category | null {
-    if (this.activeTab === "All") return null;
+    if (this.activeTab === "Overview") return null;
     const tabs = this.getOrderedTabs();
     if (!tabs.length) return null;
     return tabs.includes(this.activeTab)
@@ -451,6 +452,7 @@ export class ResearchTreeModal extends LitElement {
     levels: number[],
     researched: Set<string>,
     categoryColors: Record<Category, string>,
+    percentages: Map<string, number>,
   ) {
     if (!this.categories.length) {
       return html`<div class="empty-state">No research categories found.</div>`;
@@ -474,10 +476,13 @@ export class ResearchTreeModal extends LitElement {
                   ${techs.length
                     ? techs.map((tech) => {
                         const isResearched = researched.has(tech.id);
+                        const pct = percentages.get(tech.id) ?? 0;
                         return html`<div
                           class=${`compact-tech ${isResearched ? "researched" : ""}`}
                         >
-                          <span class="compact-name">${tech.name}</span>
+                          <span class="compact-name"
+                            >${tech.name} (${pct}%)</span
+                          >
                           ${isResearched
                             ? html`<span class="compact-check">✔</span>`
                             : ""}
@@ -502,7 +507,7 @@ export class ResearchTreeModal extends LitElement {
     if (!svg) return;
     while (svg.firstChild) svg.removeChild(svg.firstChild);
 
-    if (this.activeTab === "All") return;
+    if (this.activeTab === "Overview") return;
     const activeCategory = this.getActiveCategory();
     if (!activeCategory) return;
 
@@ -651,12 +656,25 @@ export class ResearchTreeModal extends LitElement {
     const me = this.game?.myPlayer?.();
     const priority = me?.researchPriorityTech?.() ?? null;
     const tabs = this.getOrderedTabs();
-    const isAllView = this.activeTab === "All";
+    const isAllView = this.activeTab === "Overview";
     const activeCategory = this.getActiveCategory();
     const activeTechs = activeCategory
       ? this.techs.filter((t) => t.category === activeCategory)
       : [];
     const activeMap = new Map(activeTechs.map((n) => [n.id, n] as const));
+    const percentByTechId = (() => {
+      const map = new Map<string, number>();
+      for (const tech of this.techs) {
+        const cost = Math.max(1, tech.cost || 1);
+        const beakers = me?.researchBeakers?.(tech.id) ?? 0;
+        let pct = Math.floor((beakers / cost) * 100);
+        if (!Number.isFinite(pct)) pct = 0;
+        pct = Math.max(0, Math.min(100, pct));
+        if (researched.has(tech.id)) pct = 100;
+        map.set(tech.id, pct);
+      }
+      return map;
+    })();
     const highlightTrail = (() => {
       const set = new Set<string>();
       if (!priority || !activeCategory || !activeMap.has(priority)) return set;
@@ -1244,7 +1262,7 @@ export class ResearchTreeModal extends LitElement {
           <div class="tab-bar">
             <div class="tab-buttons" role="tablist">
               ${tabs.map((cat) => {
-                const isAllTab = cat === "All";
+                const isAllTab = cat === "Overview";
                 const isActive = isAllTab ? isAllView : cat === activeCategory;
                 return html`<button
                   type="button"
@@ -1268,7 +1286,12 @@ export class ResearchTreeModal extends LitElement {
           <div class="tab-panel" role="tabpanel">
             <div class="tree-container ${isAllView ? "all-view" : ""}">
               ${isAllView
-                ? this.renderAllView(levels, researched, categoryColors)
+                ? this.renderAllView(
+                    levels,
+                    researched,
+                    categoryColors,
+                    percentByTechId,
+                  )
                 : activeCategory
                   ? html`<div
                       class="level-strip"

--- a/src/client/ResearchTreeModal.ts
+++ b/src/client/ResearchTreeModal.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import flaskIcon from "../../proprietary/images/flask.png";
 import { EventBus } from "../core/EventBus";
 import { UpgradeType } from "../core/game/Game";
@@ -18,6 +18,8 @@ import {
   SendResearchTreeSelectIntentEvent,
 } from "./Transport";
 import { renderNumber } from "./Utils";
+
+type ResearchTab = Category | "All";
 
 // Category and TechNode are imported from core so client stays in sync
 
@@ -40,14 +42,17 @@ export class ResearchTreeModal extends LitElement {
   private categories: Category[] = Array.from(
     new Set(this.techs.map((t) => t.category)),
   ) as Category[];
-  // Fixed column widths per category (px). Adjust as needed.
-  private readonly categoryColumnWidths: Record<Category, number> = {
-    Land: 360,
-    Sea: 360,
-    Air: 360,
-    Nuclear: 360,
-    Economy: 360,
-  };
+  private readonly tabOrder: ResearchTab[] = [
+    "Land",
+    "Sea",
+    "Air",
+    "Nuclear",
+    "Economy",
+    "All",
+  ];
+
+  @state()
+  private activeTab: ResearchTab = "Land";
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -190,6 +195,30 @@ export class ResearchTreeModal extends LitElement {
     `;
   }
 
+  private getOrderedTabs(): ResearchTab[] {
+    const available = new Set(this.categories);
+    const ordered = this.tabOrder.filter((cat) => {
+      if (cat === "All") return true;
+      return available.has(cat);
+    });
+    if (!ordered.includes("All") && available.size > 0) ordered.push("All");
+    return ordered.length ? ordered : [...available];
+  }
+
+  private getActiveCategory(): Category | null {
+    if (this.activeTab === "All") return null;
+    const tabs = this.getOrderedTabs();
+    if (!tabs.length) return null;
+    return tabs.includes(this.activeTab)
+      ? (this.activeTab as Category)
+      : (tabs[0] as Category);
+  }
+
+  private onTabClick(cat: ResearchTab) {
+    if (cat === this.activeTab) return;
+    this.activeTab = cat;
+  }
+
   private computePositions(): { [id: string]: DOMRect } {
     const map: { [id: string]: DOMRect } = {};
     const cards = this.renderRoot.querySelectorAll(
@@ -202,72 +231,55 @@ export class ResearchTreeModal extends LitElement {
     return map;
   }
 
-  // Apply fixed widths to each level grid so columns line up between rows
-  private applyCategoryWidths() {
-    const tree = this.renderRoot.querySelector(
-      ".tree-container",
-    ) as HTMLElement | null;
-    if (!tree) return;
-    const template = this.categories
-      .map((cat) => `${this.categoryColumnWidths[cat]}px`)
-      .join(" ");
-    tree
-      .querySelectorAll(".level-grid")
-      .forEach(
-        (grid) => ((grid as HTMLElement).style.gridTemplateColumns = template),
-      );
-  }
-
-  // Position the colored category bands to match the computed column geometry
-  private updateCategoryBandPositions() {
-    const tree = this.renderRoot.querySelector(
-      ".tree-container",
-    ) as HTMLElement | null;
-    if (!tree) return;
-    const bands = this.renderRoot.querySelectorAll(
-      ".category-bands .category-band",
-    ) as NodeListOf<HTMLElement>;
-    const firstGrid = tree.querySelector(".level-grid") as HTMLElement | null;
-    if (!firstGrid || bands.length !== this.categories.length) return;
-    const rootRect = tree.getBoundingClientRect();
-    const scrollLeft = tree.scrollLeft;
-    const contentHeight = tree.scrollHeight;
-    const slots = firstGrid.querySelectorAll(
-      ":scope > .category-slot",
-    ) as NodeListOf<HTMLElement>;
-    slots.forEach((slot, i) => {
-      const r = slot.getBoundingClientRect();
-      const left = r.left - rootRect.left + scrollLeft;
-      const width = r.width;
-      const band = bands[i];
-      band.style.position = "absolute";
-      band.style.left = `${left}px`;
-      band.style.width = `${width}px`;
-      band.style.top = "0";
-      band.style.bottom = "auto";
-      band.style.height = `${contentHeight}px`;
-    });
-    // Reveal the bands immediately after positioning
-    const bandsContainer = this.renderRoot.querySelector(
-      ".category-bands",
-    ) as HTMLElement | null;
-    if (bandsContainer) {
-      bandsContainer.style.height = `${contentHeight}px`;
-      bandsContainer.style.bottom = "auto";
-      bandsContainer.style.visibility = "visible";
-    }
-  }
-
   // Orchestrate layout updates and edge redraw
   private updateLayout() {
-    // Apply fixed widths and then position bands/edges
-    requestAnimationFrame(() => {
-      this.applyCategoryWidths();
-      requestAnimationFrame(() => {
-        this.updateCategoryBandPositions();
-        this.drawEdges();
-      });
-    });
+    requestAnimationFrame(() => this.drawEdges());
+  }
+
+  private renderAllView(
+    levels: number[],
+    researched: Set<string>,
+    categoryColors: Record<Category, string>,
+  ) {
+    if (!this.categories.length) {
+      return html`<div class="empty-state">No research categories found.</div>`;
+    }
+    return html`
+      <div class="all-view-grid">
+        ${this.categories.map((cat) => {
+          const accent = categoryColors[cat] ?? "rgba(59,130,246,0.06)";
+          return html`<div
+            class="all-column"
+            style=${`--column-accent:${accent}`}
+          >
+            <div class="all-column-title">${cat}</div>
+            ${levels.map((lvl) => {
+              const techs = this.techs.filter(
+                (t) => t.category === cat && t.level === lvl,
+              );
+              return html`<div class="compact-level">
+                <div class="compact-level-label">L${lvl}</div>
+                <div class="compact-level-techs">
+                  ${techs.length
+                    ? techs.map((tech) => {
+                        const isResearched = researched.has(tech.id);
+                        return html`<div
+                          class=${`compact-tech ${isResearched ? "researched" : ""}`}
+                        >
+                          <span class="compact-name">${tech.name}</span>
+                          ${isResearched
+                            ? html`<span class="compact-check">✔</span>`
+                            : ""}
+                        </div>`;
+                      })
+                    : html`<div class="compact-tech empty">—</div>`}
+                </div>
+              </div>`;
+            })}
+          </div>`;
+        })}
+      </div>
+    `;
   }
 
   private drawEdges() {
@@ -275,25 +287,33 @@ export class ResearchTreeModal extends LitElement {
       ".line-layer",
     ) as HTMLElement | null;
     if (!container) return;
-    const svg = container.querySelector("svg")!;
+    const svg = container.querySelector("svg");
+    if (!svg) return;
     while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    if (this.activeTab === "All") return;
+    const activeCategory = this.getActiveCategory();
+    if (!activeCategory) return;
+
+    const visibleTechs = this.techs.filter(
+      (t) => t.category === activeCategory,
+    );
+    if (!visibleTechs.length) return;
 
     const pos = this.computePositions();
     const treeEl = this.renderRoot.querySelector(
       ".tree-container",
-    ) as HTMLElement;
+    ) as HTMLElement | null;
+    if (!treeEl) return;
     const rootRect = treeEl.getBoundingClientRect();
     const scrollLeft = treeEl.scrollLeft;
     const scrollTop = treeEl.scrollTop;
 
-    // Compute highlight path based on priority and current researched
     const me = this.game?.myPlayer?.();
     const researched = this.researchedIDsFromGame();
     const priority = me?.researchPriorityTech?.() ?? null;
 
-    const byId = new Map(this.techs.map((n) => [n.id, n] as const));
-    const sameCat = (a: string, b: string) =>
-      (byId.get(a)?.category ?? "") === (byId.get(b)?.category ?? "");
+    const byId = new Map(visibleTechs.map((n) => [n.id, n] as const));
     const buildMissingPrereqPath = (targetId: string): Set<string> => {
       const path = new Set<string>();
       const seen = new Set<string>();
@@ -302,12 +322,8 @@ export class ResearchTreeModal extends LitElement {
         seen.add(tid);
         const node = byId.get(tid);
         if (!node) return;
-        const reqAll = (node.requiresAllOf ?? []).filter((p) =>
-          sameCat(p, tid),
-        );
-        const reqOne = (node.requiresOneOf ?? []).filter((p) =>
-          sameCat(p, tid),
-        );
+        const reqAll = (node.requiresAllOf ?? []).filter((p) => byId.has(p));
+        const reqOne = (node.requiresOneOf ?? []).filter((p) => byId.has(p));
         for (const r of reqAll) {
           if (!researched.has(r)) {
             path.add(r);
@@ -325,12 +341,12 @@ export class ResearchTreeModal extends LitElement {
           }
         }
       };
-      if (targetId) dfs(targetId);
+      if (targetId && byId.has(targetId)) dfs(targetId);
       return path;
     };
 
     const highlightNodes = new Set<string>();
-    if (priority) {
+    if (priority && byId.has(priority)) {
       highlightNodes.add(priority);
       const missing = buildMissingPrereqPath(priority);
       for (const id of missing) highlightNodes.add(id);
@@ -340,16 +356,16 @@ export class ResearchTreeModal extends LitElement {
       const a = pos[fromId];
       const b = pos[toId];
       if (!a || !b) return;
-      const x1 = a.left - rootRect.left + scrollLeft + a.width / 2;
-      const y1 = a.top - rootRect.top + scrollTop + a.height;
-      const x2 = b.left - rootRect.left + scrollLeft + b.width / 2;
-      const y2 = b.top - rootRect.top + scrollTop;
+      const x1 = a.right - rootRect.left + scrollLeft;
+      const y1 = a.top - rootRect.top + scrollTop + a.height / 2;
+      const x2 = b.left - rootRect.left + scrollLeft;
+      const y2 = b.top - rootRect.top + scrollTop + b.height / 2;
+      const midX = (x1 + x2) / 2;
       const path = document.createElementNS(
         "http://www.w3.org/2000/svg",
         "path",
       );
-      const mx = (x1 + x2) / 2;
-      const d = `M ${x1},${y1} C ${mx},${y1 + 20} ${mx},${y2 - 20} ${x2},${y2}`;
+      const d = `M ${x1},${y1} L ${midX},${y1} L ${midX},${y2} L ${x2},${y2}`;
       path.setAttribute("d", d);
       path.setAttribute("fill", "none");
       const isHighlighted =
@@ -361,14 +377,9 @@ export class ResearchTreeModal extends LitElement {
       svg.appendChild(path);
     };
 
-    for (const t of this.techs) {
-      const sameCat = (p: string) =>
-        this.techs.find((x) => x.id === p)?.category === t.category;
-      t.requiresAllOf ??= [];
-      t.requiresOneOf ??= [];
-
-      const reqAll = t.requiresAllOf.filter(sameCat);
-      const reqOne = t.requiresOneOf.filter(sameCat);
+    for (const t of visibleTechs) {
+      const reqAll = (t.requiresAllOf ?? []).filter((id) => byId.has(id));
+      const reqOne = (t.requiresOneOf ?? []).filter((id) => byId.has(id));
 
       for (const p of reqAll) addLine(p, t.id, "req");
       for (const p of reqOne) addLine(p, t.id, "oneof");
@@ -422,9 +433,52 @@ export class ResearchTreeModal extends LitElement {
     };
     const me = this.game?.myPlayer?.();
     const priority = me?.researchPriorityTech?.() ?? null;
+    const tabs = this.getOrderedTabs();
+    const isAllView = this.activeTab === "All";
+    const activeCategory = this.getActiveCategory();
+    const activeTechs = activeCategory
+      ? this.techs.filter((t) => t.category === activeCategory)
+      : [];
+    const activeMap = new Map(activeTechs.map((n) => [n.id, n] as const));
+    const highlightTrail = (() => {
+      const set = new Set<string>();
+      if (!priority || !activeCategory || !activeMap.has(priority)) return set;
+      const seen = new Set<string>();
+      const dfs = (tid: string) => {
+        if (seen.has(tid)) return;
+        seen.add(tid);
+        const node = activeMap.get(tid);
+        if (!node) return;
+        const reqAll = (node.requiresAllOf ?? []).filter((p) =>
+          activeMap.has(p),
+        );
+        const reqOne = (node.requiresOneOf ?? []).filter((p) =>
+          activeMap.has(p),
+        );
+        for (const r of reqAll) {
+          if (!researched.has(r)) {
+            set.add(r);
+            dfs(r);
+          }
+        }
+        if (reqOne.length > 0 && !reqOne.some((p) => researched.has(p))) {
+          const sorted = [...reqOne].sort(
+            (a, b) =>
+              (activeMap.get(a)?.level ?? 0) - (activeMap.get(b)?.level ?? 0),
+          );
+          const choice = sorted[0];
+          if (choice && !researched.has(choice)) {
+            set.add(choice);
+            dfs(choice);
+          }
+        }
+      };
+      set.add(priority);
+      dfs(priority);
+      return set;
+    })();
 
     return html`
-      <!-- Prevent outer content from scrolling; use inner tree scroll only -->
       <o-modal
         title="Research Tree"
         max-width="90vw"
@@ -432,31 +486,73 @@ export class ResearchTreeModal extends LitElement {
         content-overflow="hidden"
       >
         <style>
-          .tree-container {
-            display: grid;
-            /* Size each category column to its content and allow overall horizontal scroll */
-            grid-template-columns: repeat(5, minmax(160px, max-content));
-            grid-auto-rows: auto;
-            gap: 16px;
-            position: relative;
-            overflow-x: auto;
-            overflow-y: auto; /* inner scroll */
-            width: 100%;
-            /* constrain height to modal content so vertical scroll stays inside */
-            max-height: calc(85dvh - 100px);
-            padding-bottom: 4px; /* space for scrollbar overlay */
-            /* Firefox scrollbar */
-            scrollbar-width: thin;
-            scrollbar-color: #27476e #0e1a33; /* thumb track */
+          .tab-shell {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
           }
-          /* WebKit-based browsers scrollbar */
+          .tab-bar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            padding: 8px 4px 4px;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+          }
+          .tab-button {
+            background: #0b1428;
+            color: #9fb4d9;
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 999px;
+            padding: 6px 14px;
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            cursor: pointer;
+            transition: all 120ms ease;
+          }
+          .tab-button:hover {
+            color: #f1f5ff;
+            border-color: rgba(148, 163, 184, 0.4);
+          }
+          .tab-button.active {
+            color: #f8fbff;
+            border-color: rgba(99, 179, 237, 0.7);
+            background:
+              linear-gradient(
+                135deg,
+                rgba(59, 130, 246, 0.2),
+                rgba(6, 182, 212, 0.08)
+              ),
+              var(--tab-accent, #132035);
+            box-shadow: 0 0 20px rgba(15, 23, 42, 0.6);
+          }
+          .tab-panel {
+            background: #050b16;
+            border: 1px solid rgba(15, 23, 42, 0.9);
+            border-radius: 14px;
+            padding: 12px;
+            box-shadow:
+              inset 0 1px 0 rgba(255, 255, 255, 0.05),
+              0 10px 30px rgba(2, 6, 23, 0.65);
+          }
+          .tree-container {
+            position: relative;
+            overflow: auto;
+            max-height: calc(85dvh - 150px);
+            padding: 6px;
+            scrollbar-width: thin;
+            scrollbar-color: #27476e #0e1a33;
+          }
+          .tree-container.all-view {
+            padding: 12px;
+          }
           .tree-container::-webkit-scrollbar {
-            height: 10px; /* horizontal scrollbar thickness */
-            width: 10px; /* vertical scrollbar thickness */
-            background: transparent; /* let track define color */
+            height: 10px;
+            width: 10px;
+            background: transparent;
           }
           .tree-container::-webkit-scrollbar-track {
-            background: #0e1a33; /* deep navy track */
+            background: #0e1a33;
             border-radius: 8px;
             box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.4);
           }
@@ -473,91 +569,163 @@ export class ResearchTreeModal extends LitElement {
           .tree-container::-webkit-scrollbar-corner {
             background: #0e1a33;
           }
-          .category-bands {
-            position: absolute;
-            inset: 0;
-            display: block; /* absolute children are positioned by JS */
-            z-index: 0;
-            pointer-events: none;
-            visibility: hidden; /* avoid flicker before positioned */
-          }
-          .category-band {
-            border-left: 1px solid rgba(255, 255, 255, 0.05);
-            border-right: 1px solid rgba(0, 0, 0, 0.25);
-          }
-          .level-band {
-            grid-column: 1 / -1;
-            border-radius: 8px;
-            padding: 6px; /* slightly tighter vertical spacing */
-          }
-          .level-header {
-            font-weight: bold;
-            color: #e3edff; /* submarine heading */
-            margin-bottom: 6px; /* reduce header-bottom gap */
-            padding-left: 6px; /* add a bit of left room */
+          .level-strip {
             display: flex;
-            align-items: center;
+            gap: 36px;
+            padding: 6px;
+            min-height: 220px;
+            position: relative;
+            z-index: 2;
+          }
+          .level-column {
+            flex: 0 0 auto;
+            min-width: 220px;
+            border-radius: 12px;
+            border: 1px solid rgba(15, 23, 42, 0.95);
+            background:
+              linear-gradient(
+                180deg,
+                rgba(3, 7, 14, 0.98),
+                rgba(5, 9, 18, 0.92)
+              ),
+              var(--level-accent, rgba(59, 130, 246, 0.06));
+            padding: 12px;
+            box-shadow:
+              inset 0 1px 0 rgba(255, 255, 255, 0.04),
+              0 6px 24px rgba(2, 6, 23, 0.75);
+          }
+          .all-view-grid {
+            display: flex;
+            gap: 16px;
+            min-width: max-content;
+          }
+          .all-column {
+            flex: 0 0 220px;
+            background:
+              linear-gradient(
+                180deg,
+                rgba(4, 7, 14, 0.98),
+                rgba(6, 12, 24, 0.92)
+              ),
+              var(--column-accent, rgba(59, 130, 246, 0.05));
+            border: 1px solid rgba(15, 23, 42, 0.85);
+            border-radius: 12px;
+            padding: 10px;
+            box-shadow:
+              inset 0 1px 0 rgba(255, 255, 255, 0.04),
+              0 4px 16px rgba(2, 6, 23, 0.65);
+          }
+          .all-column-title {
+            font-weight: 600;
+            color: #f0f6ff;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+          }
+          .compact-level {
+            display: flex;
             gap: 8px;
+            align-items: flex-start;
+            margin-bottom: 6px;
           }
-          .level-grid {
-            display: grid;
-            /* Make each category column width fit its widest cell content */
-            grid-template-columns: repeat(5, minmax(160px, max-content));
-            gap: 10px; /* slightly less gap between categories */
+          .compact-level-label {
+            font-size: 10px;
+            color: #9fb4d9;
+            padding-top: 2px;
+            min-width: 22px;
           }
-          .category-slot {
+          .compact-level-techs {
             display: flex;
             flex-direction: column;
-            gap: 6px; /* slightly reduce space between title and row */
-            width: auto; /* allow to grow */
-            padding: 6px 12px; /* slightly reduce vertical padding */
-            box-sizing: border-box;
-          }
-          .tech-row {
-            display: flex;
-            flex-direction: row;
-            flex-wrap: wrap; /* keep items horizontal, wrap if too many for fixed column */
-            align-items: flex-start;
-            justify-content: center; /* center techs within the category */
-            gap: 6px; /* slightly tighter spacing between cards */
-            /* No per-row scroll; the entire tree scrolls */
-            overflow: visible;
+            gap: 4px;
             width: 100%;
           }
-          .category-title {
-            font-size: 12px;
+          .compact-tech {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 11px;
+            padding: 4px 6px;
+            border-radius: 6px;
+            background: rgba(15, 23, 42, 0.65);
+            border: 1px solid rgba(59, 130, 246, 0.15);
+            color: #dbe7ff;
+          }
+          .compact-tech.researched {
+            background: rgba(22, 82, 58, 0.35);
+            border-color: rgba(34, 197, 94, 0.4);
+          }
+          .compact-tech.empty {
+            justify-content: center;
+            font-style: italic;
+            opacity: 0.5;
+          }
+          .compact-name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+          .compact-check {
+            color: #86efac;
+            font-weight: 600;
+            margin-left: 8px;
+          }
+          .level-label {
+            font-weight: 600;
+            color: #e3edff;
+            margin-bottom: 10px;
+            letter-spacing: 0.04em;
             text-transform: uppercase;
+          }
+          .tech-stack {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+          }
+          .empty-level {
+            font-size: 12px;
+            color: #7b8ba8;
             opacity: 0.8;
-            color: #c9dbff; /* submarine label */
-            margin-bottom: 4px;
+            text-align: center;
+            border: 1px dashed rgba(125, 138, 164, 0.4);
+            border-radius: 8px;
+            padding: 16px 8px;
+          }
+          .empty-state {
+            padding: 24px;
+            text-align: center;
+            color: #9eaec9;
           }
           .tech {
-            background: #0b1220; /* submarine panel */
-            border: 1px solid #0e1a33; /* deep navy border */
-            border-radius: 8px;
-            padding: 8px;
-            color: #dbe7ff; /* soft desaturated light-blue */
+            background: linear-gradient(180deg, #122544, #0e1c33);
+            border: 1px solid rgba(59, 130, 246, 0.35);
+            border-radius: 10px;
+            padding: 10px;
+            color: #e4edff;
             position: relative;
             cursor: pointer;
             transition:
               transform 0.12s ease,
               box-shadow 0.12s ease,
               opacity 0.2s;
-            min-height: 64px;
-            /* Let multiple techs sit side-by-side */
-            flex: 0 0 auto;
-            width: 160px;
+            min-height: 72px;
+            width: 100%;
             text-align: left;
+            box-shadow:
+              0 6px 16px rgba(2, 6, 23, 0.65),
+              inset 0 0 0 1px rgba(255, 255, 255, 0.02);
           }
           .tech:hover {
-            box-shadow: 0 0 0 2px rgba(39, 71, 110, 0.8) inset; /* bluish rim */
+            box-shadow:
+              0 8px 18px rgba(2, 6, 23, 0.8),
+              0 0 0 2px rgba(59, 130, 246, 0.45) inset;
           }
           .tech.locked {
-            opacity: 1; /* allow full visibility so users can prioritize paths */
+            opacity: 1;
             cursor: pointer;
           }
           .tech.researched {
-            background: #162544; /* slightly lighter */
+            background: #162544;
             border-color: #27476e;
           }
           .tech.researched::after {
@@ -566,15 +734,14 @@ export class ResearchTreeModal extends LitElement {
             top: 6px;
             right: 8px;
             font-weight: bold;
-            color: #86efac; /* keep success green */
+            color: #86efac;
             text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
           }
           .tech-wrapper {
             display: flex;
             flex-direction: column;
             gap: 6px;
-            width: 160px;
-            flex: 0 0 auto;
+            width: 100%;
           }
           .tech-action {
             background: rgba(176, 80, 78, 0.18);
@@ -599,20 +766,18 @@ export class ResearchTreeModal extends LitElement {
             opacity: 0.65;
             cursor: not-allowed;
           }
-          /* Highlight prioritized tech with a subtle halo */
           .tech.priority {
             border-color: rgba(59, 130, 246, 0.9);
             box-shadow:
               0 0 0 2px rgba(59, 130, 246, 0.35) inset,
               0 0 10px 2px rgba(59, 130, 246, 0.25);
           }
-          /* Themed tooltip for tech descriptions (right-side) */
           .tech .tooltip {
             position: absolute;
             top: 50%;
-            left: calc(100% + 8px);
+            left: calc(100% + 12px);
             transform: translateY(-50%);
-            background: #111827; /* modal dark */
+            background: #111827;
             color: #e5e7eb;
             border: 1px solid #374151;
             border-radius: 8px;
@@ -639,14 +804,13 @@ export class ResearchTreeModal extends LitElement {
             transform: translateY(-50%);
             border-width: 6px;
             border-style: solid;
-            border-color: transparent #111827 transparent transparent; /* caret pointing right */
+            border-color: transparent #111827 transparent transparent;
             filter: drop-shadow(-1px 0 0 rgba(55, 65, 81, 0.9));
           }
           .tech:hover .tooltip {
             opacity: 1;
             visibility: visible;
           }
-          /* Research progress bar */
           .progress-track {
             width: 100%;
             height: 6px;
@@ -658,7 +822,6 @@ export class ResearchTreeModal extends LitElement {
           }
           .progress-fill {
             height: 100%;
-            /* Match flask colors exactly */
             background: linear-gradient(90deg, #00f8ff 0%, #00a6f6 100%);
             box-shadow:
               0 0 10px rgba(37, 150, 186, 0.55),
@@ -666,7 +829,6 @@ export class ResearchTreeModal extends LitElement {
               inset 0 0 4px rgba(255, 255, 255, 0.1);
           }
           .progress-fill.priority {
-            /* Same flask gradient, but stronger neon to pop more than base */
             background: linear-gradient(90deg, #00f8ff 0%, #00a6f6 100%);
             box-shadow:
               0 0 14px rgba(0, 166, 246, 0.75),
@@ -677,7 +839,6 @@ export class ResearchTreeModal extends LitElement {
           }
           .cost-inline {
             display: inline-flex;
-            /* Align bottoms of number and icon */
             align-items: flex-end;
             gap: 6px;
             font-size: 12px;
@@ -688,7 +849,6 @@ export class ResearchTreeModal extends LitElement {
           .cost-inline img {
             width: 14px;
             height: 14px;
-            /* Slight nudge up to visually align with text bottom across platforms */
             transform: translateY(-1px);
             opacity: 0.95;
           }
@@ -700,7 +860,7 @@ export class ResearchTreeModal extends LitElement {
             margin-right: 6px;
           }
           .pill-req {
-            background: rgba(176, 80, 78, 0.18); /* warning red match */
+            background: rgba(176, 80, 78, 0.18);
             color: #ffd1d1;
             border: 1px solid rgba(176, 80, 78, 0.45);
           }
@@ -736,232 +896,209 @@ export class ResearchTreeModal extends LitElement {
           }
         </style>
         ${this.renderLegend()}
-        <div class="tree-container">
-          <div class="category-bands">
-            ${this.categories.map(
-              (cat) =>
-                html`<div
-                  class="category-band"
-                  style="background:${categoryColors[cat]}"
-                ></div>`,
-            )}
+        <div class="tab-shell">
+          <div class="tab-bar" role="tablist">
+            ${tabs.map((cat) => {
+              const isAllTab = cat === "All";
+              const isActive = isAllTab ? isAllView : cat === activeCategory;
+              return html`<button
+                type="button"
+                class="tab-button ${isActive ? "active" : ""}"
+                role="tab"
+                aria-selected=${String(isActive)}
+                style=${isActive
+                  ? `--tab-accent:${isAllTab ? "rgba(148,163,184,0.25)" : (categoryColors[cat as Category] ?? "transparent")}`
+                  : ""}
+                @click=${() => this.onTabClick(cat)}
+              >
+                ${cat}
+              </button>`;
+            })}
           </div>
-          ${levels.map(
-            (lvl) => html`
-              <div class="level-band">
-                <div class="level-header">Tech Level ${lvl}</div>
-                <div class="level-grid">
-                  ${this.categories.map((cat) => {
-                    const techs = this.techs.filter(
-                      (t) => t.level === lvl && t.category === cat,
-                    );
-                    return html`
-                      <div class="category-slot">
-                        <div class="category-title">${cat}</div>
-                        <div class="tech-row">
-                          ${techs.map((tech) => {
-                            const available = this.isAvailable(
-                              tech.id,
-                              researched,
-                            );
-                            const isResearched = researched.has(tech.id);
-                            const clickable = !isResearched; // allow prioritizing locked techs
-                            // Compute highlight membership for this node
-                            const byId = new Map(
-                              this.techs.map((n) => [n.id, n] as const),
-                            );
-                            const sameCat = (a: string, b: string) =>
-                              (byId.get(a)?.category ?? "") ===
-                              (byId.get(b)?.category ?? "");
-                            const buildMissingPrereqPath = (
-                              targetId: string,
-                            ): Set<string> => {
-                              const path = new Set<string>();
-                              const seen = new Set<string>();
-                              const dfs = (tid: string) => {
-                                if (seen.has(tid)) return;
-                                seen.add(tid);
-                                const node = byId.get(tid);
-                                if (!node) return;
-                                const reqAll = (
-                                  node.requiresAllOf ?? []
-                                ).filter((p) => sameCat(p, tid));
-                                const reqOne = (
-                                  node.requiresOneOf ?? []
-                                ).filter((p) => sameCat(p, tid));
-                                for (const r of reqAll) {
-                                  if (!researched.has(r)) {
-                                    path.add(r);
-                                    dfs(r);
-                                  }
-                                }
-                                if (
-                                  reqOne.length > 0 &&
-                                  !reqOne.some((p) => researched.has(p))
-                                ) {
-                                  const sorted = [...reqOne].sort(
-                                    (a, b) =>
-                                      (byId.get(a)?.level ?? 0) -
-                                      (byId.get(b)?.level ?? 0),
+          <div class="tab-panel" role="tabpanel">
+            <div class="tree-container ${isAllView ? "all-view" : ""}">
+              ${isAllView
+                ? this.renderAllView(levels, researched, categoryColors)
+                : activeCategory
+                  ? html`<div
+                      class="level-strip"
+                      style=${`--level-accent:${categoryColors[activeCategory] ?? "transparent"}`}
+                    >
+                      ${levels.map((lvl) => {
+                        const techsForLevel = this.techs.filter(
+                          (t) =>
+                            t.level === lvl && t.category === activeCategory,
+                        );
+                        return html`<div class="level-column">
+                          <div class="level-label">Tech Level ${lvl}</div>
+                          <div class="tech-stack">
+                            ${techsForLevel.length
+                              ? techsForLevel.map((tech) => {
+                                  const available = this.isAvailable(
+                                    tech.id,
+                                    researched,
                                   );
-                                  const choice = sorted[0];
-                                  if (choice && !researched.has(choice)) {
-                                    path.add(choice);
-                                    dfs(choice);
-                                  }
-                                }
-                              };
-                              if (priority) dfs(priority);
-                              return path;
-                            };
-                            const highlightSet = (() => {
-                              const s = new Set<string>();
-                              if (priority) {
-                                s.add(priority);
-                                const missing =
-                                  buildMissingPrereqPath(priority);
-                                for (const id of missing) s.add(id);
-                              }
-                              return s;
-                            })();
-                            const inHighlight = highlightSet.has(tech.id);
-
-                            const classes = [
-                              "tech",
-                              available ? "" : "locked",
-                              isResearched ? "researched" : "",
-                              inHighlight ? "priority" : "",
-                            ]
-                              .filter(Boolean)
-                              .join(" ");
-                            const action = this.renderScorchedEarthAction(
-                              tech,
-                              me ?? null,
-                              isResearched,
-                            );
-                            return html`
-                              <div class="tech-wrapper">
-                                <button
-                                  class=${classes}
-                                  data-id=${tech.id}
-                                  @click=${() => this.onTechClick(tech.id)}
-                                  title=${""}
-                                  ?disabled=${!clickable}
-                                >
-                                  <div class="tooltip">
-                                    <div
-                                      style="font-weight:600;margin-bottom:4px;"
+                                  const isResearched = researched.has(tech.id);
+                                  const clickable = !isResearched;
+                                  const inHighlight = highlightTrail.has(
+                                    tech.id,
+                                  );
+                                  const classes = [
+                                    "tech",
+                                    available ? "" : "locked",
+                                    isResearched ? "researched" : "",
+                                    inHighlight ? "priority" : "",
+                                  ]
+                                    .filter(Boolean)
+                                    .join(" ");
+                                  const action = this.renderScorchedEarthAction(
+                                    tech,
+                                    me ?? null,
+                                    isResearched,
+                                  );
+                                  return html`<div class="tech-wrapper">
+                                    <button
+                                      class=${classes}
+                                      data-id=${tech.id}
+                                      @click=${() => this.onTechClick(tech.id)}
+                                      title=${""}
+                                      ?disabled=${!clickable}
                                     >
-                                      ${tech.name}
-                                    </div>
-                                    ${tech.description
-                                      ? html`<div
-                                          style="opacity:.9;margin-bottom:6px;"
+                                      <div class="tooltip">
+                                        <div
+                                          style="font-weight:600;margin-bottom:4px;"
                                         >
-                                          ${tech.description}
-                                        </div>`
-                                      : ""}
-                                    ${(() => {
-                                      const meLocal = this.game?.myPlayer?.();
-                                      const b =
-                                        meLocal?.researchBeakers?.(tech.id) ??
-                                        0;
-                                      const pct = Math.min(
-                                        100,
-                                        Math.floor(
-                                          (b / (tech.cost || 1)) * 100,
-                                        ),
-                                      );
-                                      return html`<div
-                                        style="font-size:11px;opacity:.9;"
-                                      >
-                                        <div class="cost-inline" translate="no">
-                                          <span
-                                            >Cost:
-                                            ${tech.cost.toLocaleString()}</span
-                                          >
-                                          <img
-                                            src=${flaskIcon}
-                                            alt="research cost"
-                                          />
+                                          ${tech.name}
                                         </div>
-                                        ${isResearched
-                                          ? html`<div>Status: Completed</div>`
-                                          : html`<div>
-                                              Progress: ${b.toLocaleString()} /
-                                              ${tech.cost.toLocaleString()}
-                                              (${pct}%)
-                                            </div>`}
-                                      </div>`;
-                                    })()}
-                                  </div>
-                                  <div
-                                    style="font-weight:600; margin-bottom:6px;"
-                                  >
-                                    ${tech.name}
-                                  </div>
-                                  <div class="cost-inline" translate="no">
-                                    <span>${tech.cost.toLocaleString()}</span>
-                                    <img src=${flaskIcon} alt="research cost" />
-                                  </div>
-                                  ${!isResearched && me
-                                    ? (() => {
-                                        const b =
-                                          me.researchBeakers?.(tech.id) ?? 0;
-                                        const pct = Math.min(
-                                          100,
-                                          Math.floor(
-                                            (b / (tech.cost || 1)) * 100,
-                                          ),
-                                        );
-                                        return b > 0
-                                          ? html`<div class="progress-track">
-                                              <div
-                                                class="progress-fill ${priority ===
-                                                tech.id
-                                                  ? "priority"
-                                                  : ""}"
-                                                style="width:${pct}%"
-                                              ></div>
+                                        ${tech.description
+                                          ? html`<div
+                                              style="opacity:.9;margin-bottom:6px;"
+                                            >
+                                              ${tech.description}
                                             </div>`
-                                          : "";
-                                      })()
-                                    : ""}
-                                  <div>
-                                    ${tech.requiresAllOf?.length
-                                      ? html`<span class="pill pill-req"
-                                          >Requires:
-                                          ${tech.requiresAllOf.length}</span
-                                        >`
-                                      : ""}
-                                    ${tech.requiresOneOf?.length
-                                      ? html`<span class="pill pill-oneof"
-                                          >One of:
-                                          ${tech.requiresOneOf.length}</span
-                                        >`
-                                      : ""}
-                                    ${priority === tech.id && !isResearched
-                                      ? html`<span
-                                          class="pill"
-                                          style="background:rgba(59,130,246,0.18);color:#cfe3ff;border:1px solid rgba(59,130,246,0.45);"
-                                          >Priority</span
-                                        >`
-                                      : ""}
-                                  </div>
-                                </button>
-                                ${action}
-                              </div>
-                            `;
-                          })}
-                        </div>
-                      </div>
-                    `;
-                  })}
-                </div>
-              </div>
-            `,
-          )}
-          <div class="line-layer"><svg></svg></div>
+                                          : ""}
+                                        ${(() => {
+                                          const meLocal =
+                                            this.game?.myPlayer?.();
+                                          const b =
+                                            meLocal?.researchBeakers?.(
+                                              tech.id,
+                                            ) ?? 0;
+                                          const pct = Math.min(
+                                            100,
+                                            Math.floor(
+                                              (b / (tech.cost || 1)) * 100,
+                                            ),
+                                          );
+                                          return html`<div
+                                            style="font-size:11px;opacity:.9;"
+                                          >
+                                            <div
+                                              class="cost-inline"
+                                              translate="no"
+                                            >
+                                              <span
+                                                >Cost:
+                                                ${tech.cost.toLocaleString()}</span
+                                              >
+                                              <img
+                                                src=${flaskIcon}
+                                                alt="research cost"
+                                              />
+                                            </div>
+                                            ${isResearched
+                                              ? html`<div>
+                                                  Status: Completed
+                                                </div>`
+                                              : html`<div>
+                                                  Progress:
+                                                  ${b.toLocaleString()} /
+                                                  ${tech.cost.toLocaleString()}
+                                                  (${pct}%)
+                                                </div>`}
+                                          </div>`;
+                                        })()}
+                                      </div>
+                                      <div
+                                        style="font-weight:600; margin-bottom:6px;"
+                                      >
+                                        ${tech.name}
+                                      </div>
+                                      <div class="cost-inline" translate="no">
+                                        <span
+                                          >${tech.cost.toLocaleString()}</span
+                                        >
+                                        <img
+                                          src=${flaskIcon}
+                                          alt="research cost"
+                                        />
+                                      </div>
+                                      ${!isResearched && me
+                                        ? (() => {
+                                            const b =
+                                              me.researchBeakers?.(tech.id) ??
+                                              0;
+                                            const pct = Math.min(
+                                              100,
+                                              Math.floor(
+                                                (b / (tech.cost || 1)) * 100,
+                                              ),
+                                            );
+                                            return b > 0
+                                              ? html`<div
+                                                  class="progress-track"
+                                                >
+                                                  <div
+                                                    class="progress-fill ${priority ===
+                                                    tech.id
+                                                      ? "priority"
+                                                      : ""}"
+                                                    style="width:${pct}%"
+                                                  ></div>
+                                                </div>`
+                                              : "";
+                                          })()
+                                        : ""}
+                                      <div>
+                                        ${tech.requiresAllOf?.length
+                                          ? html`<span class="pill pill-req"
+                                              >Requires:
+                                              ${tech.requiresAllOf.length}</span
+                                            >`
+                                          : ""}
+                                        ${tech.requiresOneOf?.length
+                                          ? html`<span class="pill pill-oneof"
+                                              >One of:
+                                              ${tech.requiresOneOf.length}</span
+                                            >`
+                                          : ""}
+                                        ${priority === tech.id && !isResearched
+                                          ? html`<span
+                                              class="pill"
+                                              style="background:rgba(59,130,246,0.18);color:#cfe3ff;border:1px solid rgba(59,130,246,0.45);"
+                                              >Priority</span
+                                            >`
+                                          : ""}
+                                      </div>
+                                    </button>
+                                    ${action}
+                                  </div>`;
+                                })
+                              : html`<div class="empty-level">
+                                  No techs at this level
+                                </div>`}
+                          </div>
+                        </div>`;
+                      })}
+                    </div>`
+                  : html`<div class="empty-state">
+                      No research categories found.
+                    </div>`}
+              ${!isAllView
+                ? html`<div class="line-layer"><svg></svg></div>`
+                : ""}
+            </div>
+          </div>
         </div>
       </o-modal>
     `;

--- a/src/client/ResearchTreeModal.ts
+++ b/src/client/ResearchTreeModal.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from "lit";
+import { LitElement, html, type PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import flaskIcon from "../../proprietary/images/flask.png";
 import { EventBus } from "../core/EventBus";
@@ -12,6 +12,13 @@ import {
 } from "../core/tech/ResearchTree";
 import { RESEARCH_TECH_IDS } from "../core/tech/TechEffects";
 import "./components/baseComponents/Modal";
+import {
+  INVESTMENT_REQUEST_EVENT,
+  INVESTMENT_SYNC_EVENT,
+  INVESTMENT_SYNC_REQUEST_EVENT,
+  type InvestmentRequestDetail,
+  type InvestmentSyncDetail,
+} from "./events/InvestmentEvents";
 import { CloseViewEvent } from "./InputHandler";
 import {
   SendPurchaseUpgradeIntentEvent,
@@ -54,13 +61,36 @@ export class ResearchTreeModal extends LitElement {
   @state()
   private activeTab: ResearchTab = "Land";
 
+  @state()
+  private roadInvestmentRate = 0;
+
+  @state()
+  private researchInvestmentRate = 0;
+
+  @state()
+  private lockRoad = false;
+
+  @state()
+  private lockResearch = false;
+
+  @state()
+  private roadInvestmentEnabled = false;
+
   connectedCallback(): void {
     super.connectedCallback();
+    window.addEventListener(
+      INVESTMENT_SYNC_EVENT,
+      this.handleInvestmentSync as EventListener,
+    );
+    if (this.visible) {
+      this.requestInvestmentSync();
+    }
     if (this.visible) this.open();
   }
 
   open() {
     this.modalEl?.open();
+    this.requestInvestmentSync();
     // Perform a full layout pass on the next frame after opening
     requestAnimationFrame(() => this.updateLayout());
     // Start a light refresh loop to reflect game state (gold/upgrades) while open
@@ -217,6 +247,187 @@ export class ResearchTreeModal extends LitElement {
   private onTabClick(cat: ResearchTab) {
     if (cat === this.activeTab) return;
     this.activeTab = cat;
+  }
+
+  private handleInvestmentSync = (event: Event) => {
+    const { detail } = event as CustomEvent<InvestmentSyncDetail>;
+    if (!detail) return;
+    this.roadInvestmentRate = detail.road;
+    this.researchInvestmentRate = detail.research;
+    this.lockRoad = detail.lockRoad;
+    this.lockResearch = detail.lockResearch;
+    this.roadInvestmentEnabled = detail.roadEnabled;
+  };
+
+  private requestInvestmentSync() {
+    window.dispatchEvent(new CustomEvent(INVESTMENT_SYNC_REQUEST_EVENT));
+  }
+
+  private dispatchInvestmentRequest(detail: InvestmentRequestDetail) {
+    window.dispatchEvent(
+      new CustomEvent<InvestmentRequestDetail>(INVESTMENT_REQUEST_EVENT, {
+        detail,
+      }),
+    );
+  }
+
+  private handleInvestmentInput(slider: "road" | "research", event: Event) {
+    const input = event.target as HTMLInputElement;
+    const value = Math.max(
+      0,
+      Math.min(1, (parseInt(input.value || "0", 10) || 0) / 100),
+    );
+    const currentValue =
+      slider === "road" ? this.roadInvestmentRate : this.researchInvestmentRate;
+    const locked = slider === "road" ? this.lockRoad : this.lockResearch;
+    const enabled = slider === "road" ? this.canUseRoadSlider() : true;
+    if (locked || !enabled) {
+      input.value = Math.round(currentValue * 100).toString();
+      return;
+    }
+    this.dispatchInvestmentRequest({ type: "set", slider, value });
+  }
+
+  private handleInvestmentToggle(slider: "road" | "research") {
+    if (slider === "road" && !this.canUseRoadSlider()) return;
+    this.dispatchInvestmentRequest({ type: "toggle-lock", slider });
+  }
+
+  private canUseRoadSlider(): boolean {
+    if (this.roadInvestmentEnabled) return true;
+    const me = this.game?.myPlayer?.();
+    return me?.hasUpgrade?.(UpgradeType.Roads) ?? false;
+  }
+
+  private renderRoadSlider(me: PlayerView | null) {
+    const hasRoads = this.canUseRoadSlider();
+    const displayValue = hasRoads ? this.roadInvestmentRate : 0;
+    const percent = Math.round(displayValue * 100);
+    const quality = me?.roadNetworkQuality?.() ?? 100;
+    const completion = me?.roadNetworkCompletion?.() ?? 100;
+    const tooltip = hasRoads
+      ? this.lockRoad
+        ? "Slider is locked. Double-click to unlock."
+        : "Double-click slider to lock."
+      : "Research Post-War Reconstruction to enable road investment.";
+    const breakEvenMarker = this.renderRoadBreakEvenMarker(me, hasRoads);
+    return html`
+      <div
+        class="investment-slider ${hasRoads ? "" : "disabled"}"
+        translate="no"
+      >
+        <label class="investment-label">
+          <span>
+            Road investment: ${percent}% ·
+            <span style="white-space:nowrap;"
+              >Quality ${quality.toFixed(1)}%</span
+            >
+            ·
+            <span style="white-space:nowrap;"
+              >Completion: ${Math.round(completion)}%</span
+            >
+          </span>
+          ${this.lockRoad
+            ? html`<span class="lock-badge">
+                <svg class="lock-icon" viewBox="0 0 24 24">
+                  <path
+                    d="M8 10V7a4 4 0 118 0v3h1a2 2 0 012 2v8a2 2 0 01-2 2H7a2 2 0 01-2-2v-8a2 2 0 012-2h1zm2 0h4V7a2 2 0 10-4 0v3z"
+                  />
+                </svg>
+                Locked
+              </span>`
+            : ""}
+        </label>
+        <div class="investment-track-wrapper" title=${tooltip}>
+          <div class="investment-track-bg"></div>
+          <div
+            class="investment-track-fill"
+            style="width:${Math.min(100, Math.max(0, percent))}%;"
+          ></div>
+          ${breakEvenMarker}
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            .value=${percent.toString()}
+            class="investment-input ${this.lockRoad ? "locked" : ""}"
+            ?disabled=${!hasRoads}
+            @input=${(e: Event) => this.handleInvestmentInput("road", e)}
+            @dblclick=${() => hasRoads && this.handleInvestmentToggle("road")}
+          />
+        </div>
+        <div class="investment-hint">${tooltip}</div>
+      </div>
+    `;
+  }
+
+  private renderRoadBreakEvenMarker(me: PlayerView | null, enabled: boolean) {
+    if (!enabled || !me) return "";
+    const config = this.game?.config?.();
+    if (!config) return "";
+    const pxPerSecond = me.roadNetPixelsPerSecond?.() ?? 0;
+    const base = config.roadConstructionBaseCost();
+    const maintMult = config.roadMaintenanceMultiplier();
+    const length = me.roadNetworkLength?.() ?? 0;
+    const quality = me.roadNetworkQuality?.() ?? 100;
+    const maintenancePerSecond =
+      (length * base * maintMult * Math.max(0.1, quality / 100)) / 60;
+    const grossPerSecond = pxPerSecond * base;
+    let breakEven = 0;
+    if (grossPerSecond > 0) breakEven = maintenancePerSecond / grossPerSecond;
+    else breakEven = maintenancePerSecond > 0 ? 1 : 0;
+    if (!Number.isFinite(breakEven)) breakEven = 0;
+    breakEven = Math.max(0, Math.min(1, breakEven));
+    if (breakEven <= 0 || breakEven >= 1) return "";
+    const leftPct = (breakEven * 100).toFixed(2);
+    return html`<div
+      class="investment-marker"
+      style="left:${leftPct}%;"
+      title=${`Break-even: ${(breakEven * 100).toFixed(0)}%`}
+    ></div>`;
+  }
+
+  private renderResearchSlider() {
+    const percent = Math.round(this.researchInvestmentRate * 100);
+    const tooltip = this.lockResearch
+      ? "Slider is locked. Double-click to unlock."
+      : "Double-click slider to lock.";
+    return html`
+      <div class="investment-slider" translate="no">
+        <label class="investment-label">
+          Research investment: ${percent}%
+          ${this.lockResearch
+            ? html`<span class="lock-badge">
+                <svg class="lock-icon" viewBox="0 0 24 24">
+                  <path
+                    d="M8 10V7a4 4 0 118 0v3h1a2 2 0 012 2v8a2 2 0 01-2 2H7a2 2 0 01-2-2v-8a2 2 0 012-2h1zm2 0h4V7a2 2 0 10-4 0v3z"
+                  />
+                </svg>
+                Locked
+              </span>`
+            : ""}
+        </label>
+        <div class="investment-track-wrapper" title=${tooltip}>
+          <div class="investment-track-bg"></div>
+          <div
+            class="investment-track-fill"
+            style="width:${Math.min(100, Math.max(0, percent))}%;"
+          ></div>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            .value=${percent.toString()}
+            class="investment-input ${this.lockResearch ? "locked" : ""}"
+            @input=${(e: Event) => this.handleInvestmentInput("research", e)}
+            @dblclick=${() => this.handleInvestmentToggle("research")}
+          />
+        </div>
+        <div class="investment-hint">${tooltip}</div>
+      </div>
+    `;
   }
 
   private computePositions(): { [id: string]: DOMRect } {
@@ -386,7 +597,8 @@ export class ResearchTreeModal extends LitElement {
     }
   }
 
-  protected firstUpdated(): void {
+  protected firstUpdated(_changed: PropertyValues): void {
+    super.firstUpdated(_changed);
     setTimeout(() => this.updateLayout(), 0);
     window.addEventListener("resize", this.handleResize);
     // Watch scroll on the whole tree container (both axes)
@@ -398,6 +610,7 @@ export class ResearchTreeModal extends LitElement {
         passive: true,
       } as any,
     );
+    this.requestInvestmentSync();
   }
 
   disconnectedCallback(): void {
@@ -406,6 +619,10 @@ export class ResearchTreeModal extends LitElement {
     // content no longer scrolls for this modal; listener removed
     const tree = this.renderRoot.querySelector(".tree-container");
     tree?.removeEventListener("scroll", this.handleResize as any);
+    window.removeEventListener(
+      INVESTMENT_SYNC_EVENT,
+      this.handleInvestmentSync as EventListener,
+    );
   }
 
   private handleResize = () => {
@@ -494,9 +711,15 @@ export class ResearchTreeModal extends LitElement {
           .tab-bar {
             display: flex;
             flex-wrap: wrap;
-            gap: 8px;
+            gap: 12px;
             padding: 8px 4px 4px;
             border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+            align-items: flex-end;
+          }
+          .tab-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
           }
           .tab-button {
             background: #0b1428;
@@ -534,6 +757,127 @@ export class ResearchTreeModal extends LitElement {
             box-shadow:
               inset 0 1px 0 rgba(255, 255, 255, 0.05),
               0 10px 30px rgba(2, 6, 23, 0.65);
+          }
+          .investment-cluster {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            margin-left: auto;
+            align-items: flex-start;
+            margin-top: -40px;
+          }
+          .investment-slider {
+            min-width: 260px;
+            width: clamp(260px, 40vw, 390px);
+            color: #dbe7ff;
+            font-size: 12px;
+          }
+          .investment-slider.disabled {
+            opacity: 0.5;
+          }
+          .investment-label {
+            font-size: 12px;
+            margin-bottom: 4px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+          }
+          .investment-track-wrapper {
+            position: relative;
+            height: 24px;
+          }
+          .investment-track-bg {
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 50%;
+            transform: translateY(-50%);
+            height: 6px;
+            border-radius: 999px;
+            background-color: rgba(24, 39, 66, 0.85);
+          }
+          .investment-track-fill {
+            position: absolute;
+            left: 0;
+            top: 50%;
+            transform: translateY(-50%);
+            height: 6px;
+            border-radius: 999px;
+            background: linear-gradient(90deg, #5ac8fa, #2563eb);
+          }
+          .investment-input {
+            position: absolute;
+            inset: 0;
+            margin: 0;
+            height: 100%;
+            background: transparent;
+            -webkit-appearance: none;
+            appearance: none;
+            outline: none;
+          }
+          .investment-input::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #0b1220;
+            border: 2px solid #27476e;
+            cursor: pointer;
+            box-shadow: 0 0 0 1px rgba(39, 71, 110, 0.35) inset;
+          }
+          .investment-input::-moz-range-thumb {
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #0b1220;
+            border: 2px solid #27476e;
+            cursor: pointer;
+            box-shadow: 0 0 0 1px rgba(39, 71, 110, 0.35) inset;
+          }
+          .investment-input::-webkit-slider-runnable-track,
+          .investment-input::-moz-range-track {
+            background: transparent;
+          }
+          .investment-input.locked::-webkit-slider-thumb,
+          .investment-input.locked::-moz-range-thumb {
+            border-color: #f59e0b;
+            box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.45) inset;
+          }
+          .investment-marker {
+            position: absolute;
+            top: 0;
+            width: 2px;
+            height: 8px;
+            background: rgba(255, 255, 255, 0.85);
+            transform: translateX(-1px);
+            border-radius: 1px;
+          }
+          .investment-hint {
+            font-size: 10px;
+            opacity: 0.65;
+            margin-top: 2px;
+          }
+          .investment-meta {
+            font-size: 11px;
+            opacity: 0.75;
+            margin-top: 4px;
+            text-align: right;
+          }
+          .lock-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 1px 6px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            font-size: 10px;
+          }
+          .lock-icon {
+            width: 10px;
+            height: 10px;
+            fill: currentColor;
           }
           .tree-container {
             position: relative;
@@ -897,23 +1241,29 @@ export class ResearchTreeModal extends LitElement {
         </style>
         ${this.renderLegend()}
         <div class="tab-shell">
-          <div class="tab-bar" role="tablist">
-            ${tabs.map((cat) => {
-              const isAllTab = cat === "All";
-              const isActive = isAllTab ? isAllView : cat === activeCategory;
-              return html`<button
-                type="button"
-                class="tab-button ${isActive ? "active" : ""}"
-                role="tab"
-                aria-selected=${String(isActive)}
-                style=${isActive
-                  ? `--tab-accent:${isAllTab ? "rgba(148,163,184,0.25)" : (categoryColors[cat as Category] ?? "transparent")}`
-                  : ""}
-                @click=${() => this.onTabClick(cat)}
-              >
-                ${cat}
-              </button>`;
-            })}
+          <div class="tab-bar">
+            <div class="tab-buttons" role="tablist">
+              ${tabs.map((cat) => {
+                const isAllTab = cat === "All";
+                const isActive = isAllTab ? isAllView : cat === activeCategory;
+                return html`<button
+                  type="button"
+                  class="tab-button ${isActive ? "active" : ""}"
+                  role="tab"
+                  aria-selected=${String(isActive)}
+                  style=${isActive
+                    ? `--tab-accent:${isAllTab ? "rgba(148,163,184,0.25)" : (categoryColors[cat as Category] ?? "transparent")}`
+                    : ""}
+                  @click=${() => this.onTabClick(cat)}
+                >
+                  ${cat}
+                </button>`;
+              })}
+            </div>
+            <div class="investment-cluster">
+              ${this.renderResearchSlider()}
+              ${this.renderRoadSlider(me ?? null)}
+            </div>
           </div>
           <div class="tab-panel" role="tabpanel">
             <div class="tree-container ${isAllView ? "all-view" : ""}">

--- a/src/client/events/InvestmentEvents.ts
+++ b/src/client/events/InvestmentEvents.ts
@@ -1,0 +1,26 @@
+export const INVESTMENT_SYNC_EVENT = "investment-sync";
+export const INVESTMENT_SYNC_REQUEST_EVENT = "investment-sync-request";
+export const INVESTMENT_REQUEST_EVENT = "investment-request-change";
+
+export type InvestmentSlider = "prod" | "road" | "research";
+
+export type InvestmentSyncDetail = {
+  prod: number;
+  road: number;
+  research: number;
+  lockProd: boolean;
+  lockRoad: boolean;
+  lockResearch: boolean;
+  roadEnabled: boolean;
+};
+
+export type InvestmentRequestDetail =
+  | {
+      type: "set";
+      slider: InvestmentSlider;
+      value: number;
+    }
+  | {
+      type: "toggle-lock";
+      slider: InvestmentSlider;
+    };

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -29,6 +29,7 @@ import { RoadLayer } from "./layers/RoadLayer";
 import { SpawnTimer } from "./layers/SpawnTimer";
 import { StructureLayer } from "./layers/StructureLayer";
 import { TeamStats } from "./layers/TeamStats";
+import { TechUnlockNotification } from "./layers/TechUnlockNotification";
 import { TerrainLayer } from "./layers/TerrainLayer";
 import { TerritoryLayer } from "./layers/TerritoryLayer";
 import { TopBar } from "./layers/TopBar";
@@ -125,6 +126,15 @@ export function createRenderer(
   }
   researchToggleButton.eventBus = eventBus;
   researchToggleButton.game = game;
+
+  const techUnlockNotification = document.querySelector(
+    "tech-unlock-notification",
+  ) as TechUnlockNotification;
+  if (!(techUnlockNotification instanceof TechUnlockNotification)) {
+    console.error("TechUnlockNotification element not found in the DOM");
+  }
+  techUnlockNotification.eventBus = eventBus;
+  techUnlockNotification.game = game;
 
   const eventsDisplay = document.querySelector(
     "events-display",
@@ -248,6 +258,7 @@ export function createRenderer(
     controlPanel,
     controlPanel2,
     researchToggleButton,
+    techUnlockNotification,
     playerInfo,
     winModel,
     optionsMenu,

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -24,6 +24,7 @@ import { PlayerInfoOverlay } from "./layers/PlayerInfoOverlay";
 import { PlayerPanel } from "./layers/PlayerPanel";
 import { RadialMenu } from "./layers/RadialMenu";
 import { ReplayPanel } from "./layers/ReplayPanel";
+import { ResearchToggleButton } from "./layers/ResearchToggleButton";
 import { RoadLayer } from "./layers/RoadLayer";
 import { SpawnTimer } from "./layers/SpawnTimer";
 import { StructureLayer } from "./layers/StructureLayer";
@@ -115,6 +116,15 @@ export function createRenderer(
   controlPanel2.eventBus = eventBus;
   controlPanel2.uiState = uiState;
   controlPanel2.game = game;
+
+  const researchToggleButton = document.querySelector(
+    "research-toggle-button",
+  ) as ResearchToggleButton;
+  if (!(researchToggleButton instanceof ResearchToggleButton)) {
+    console.error("ResearchToggleButton element not found in the DOM");
+  }
+  researchToggleButton.eventBus = eventBus;
+  researchToggleButton.game = game;
 
   const eventsDisplay = document.querySelector(
     "events-display",
@@ -237,6 +247,7 @@ export function createRenderer(
     gameLeftSidebar,
     controlPanel,
     controlPanel2,
+    researchToggleButton,
     playerInfo,
     winModel,
     optionsMenu,

--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -11,6 +11,13 @@ import {
 import { GameView, PlayerView } from "../../../core/game/GameView";
 import { getTechNodes } from "../../../core/tech/ResearchTree";
 import { getTechMeta, RESEARCH_TECH_IDS } from "../../../core/tech/TechEffects";
+import {
+  INVESTMENT_REQUEST_EVENT,
+  INVESTMENT_SYNC_EVENT,
+  INVESTMENT_SYNC_REQUEST_EVENT,
+  type InvestmentRequestDetail,
+  type InvestmentSyncDetail,
+} from "../../events/InvestmentEvents";
 import { PlayerListChangedEvent } from "../../events/PlayerListChangedEvent";
 import { AttackRatioEvent } from "../../InputHandler";
 import "../../ResearchTreeModal";
@@ -184,6 +191,55 @@ export class ControlPanel2 extends LitElement implements Layer {
     UnitType.Academy,
     UnitType.City,
   ];
+
+  private readonly investmentRequestHandler = (event: Event) => {
+    const { detail } = event as CustomEvent<InvestmentRequestDetail>;
+    if (!detail) return;
+    if (detail.type === "set") {
+      const value = Math.max(0, Math.min(1, detail.value ?? 0));
+      if (detail.slider === "road" && !this.playerHasRoadsUpgrade()) return;
+      this.applyInvestmentChange(detail.slider, value);
+    } else if (detail.type === "toggle-lock") {
+      if (detail.slider === "prod") {
+        this._lockProd = !this._lockProd;
+      } else if (detail.slider === "road") {
+        if (!this.playerHasRoadsUpgrade()) return;
+        this._lockRoad = !this._lockRoad;
+      } else if (detail.slider === "research") {
+        this._lockResearch = !this._lockResearch;
+      }
+      this.emitInvestmentSync();
+      this.requestUpdate();
+    }
+  };
+
+  private readonly investmentSyncRequestHandler = () => {
+    this.emitInvestmentSync();
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener(
+      INVESTMENT_REQUEST_EVENT,
+      this.investmentRequestHandler as EventListener,
+    );
+    window.addEventListener(
+      INVESTMENT_SYNC_REQUEST_EVENT,
+      this.investmentSyncRequestHandler,
+    );
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener(
+      INVESTMENT_REQUEST_EVENT,
+      this.investmentRequestHandler as EventListener,
+    );
+    window.removeEventListener(
+      INVESTMENT_SYNC_REQUEST_EVENT,
+      this.investmentSyncRequestHandler,
+    );
+    super.disconnectedCallback();
+  }
 
   init() {
     this.attackRatio = Number(
@@ -569,6 +625,79 @@ export class ControlPanel2 extends LitElement implements Layer {
     return { prod: currentProd, road: currentRoad, research: currentResearch };
   }
 
+  private applyInvestmentChange(
+    changed: "prod" | "road" | "research",
+    proposed: number,
+  ) {
+    const { prod, road, research } = this._applyTripleInvestmentConstraint(
+      changed,
+      proposed,
+    );
+    this.commitInvestmentRates(prod, road, research);
+  }
+
+  private commitInvestmentRates(
+    prod: number,
+    road: number,
+    research: number,
+  ): boolean {
+    const prodChanged = Math.abs(prod - this.investmentRate) > 1e-6;
+    const roadChanged = Math.abs(road - this._roadInvestmentRate) > 1e-6;
+    const researchChanged =
+      Math.abs(research - this._researchInvestmentRate) > 1e-6;
+
+    if (!prodChanged && !roadChanged && !researchChanged) {
+      return false;
+    }
+
+    this.investmentRate = prod;
+    this._roadInvestmentRate = road;
+    this._researchInvestmentRate = research;
+
+    if (prodChanged) {
+      this.onInvestmentRateChange(this.investmentRate);
+      this.uiState.investmentRate = this.investmentRate;
+      localStorage.setItem(
+        "settings.investmentRate",
+        this.investmentRate.toString(),
+      );
+    }
+    if (roadChanged) {
+      this.onRoadInvestmentChange(this._roadInvestmentRate);
+      localStorage.setItem(
+        "settings.roadInvestmentRate",
+        this._roadInvestmentRate.toString(),
+      );
+    }
+    if (researchChanged) {
+      this.onResearchInvestmentChange(this._researchInvestmentRate);
+      localStorage.setItem(
+        "settings.researchInvestmentRate",
+        this._researchInvestmentRate.toString(),
+      );
+    }
+
+    this.emitInvestmentSync();
+    return true;
+  }
+
+  private emitInvestmentSync() {
+    const detail: InvestmentSyncDetail = {
+      prod: this.investmentRate,
+      road: this._roadInvestmentRate,
+      research: this._researchInvestmentRate,
+      lockProd: this._lockProd,
+      lockRoad: this._lockRoad,
+      lockResearch: this._lockResearch,
+      roadEnabled: this.playerHasRoadsUpgrade(),
+    };
+    window.dispatchEvent(
+      new CustomEvent<InvestmentSyncDetail>(INVESTMENT_SYNC_EVENT, {
+        detail,
+      }),
+    );
+  }
+
   renderLayer(context: CanvasRenderingContext2D) {
     // Render any necessary canvas elements
   }
@@ -593,6 +722,11 @@ export class ControlPanel2 extends LitElement implements Layer {
   delta(): number {
     const d = this._population - this.targetTroops();
     return d;
+  }
+
+  private playerHasRoadsUpgrade(): boolean {
+    const player = this.game?.myPlayer?.();
+    return player?.hasUpgrade?.(UpgradeType.Roads) ?? false;
   }
 
   private _getPlayersInAirfieldRange(): PlayerView[] {
@@ -1353,59 +1487,15 @@ export class ControlPanel2 extends LitElement implements Layer {
                           ._lockProd
                           ? "slider-locked"
                           : ""}"
-                        @dblclick=${() => (this._lockProd = !this._lockProd)}
+                        @dblclick=${() => {
+                          this._lockProd = !this._lockProd;
+                          this.emitInvestmentSync();
+                        }}
                         @input=${(e: Event) => {
-                          if (this._lockProd) {
-                            (e.target as HTMLInputElement).value = (
-                              this.investmentRate * 100
-                            ).toString();
-                            return;
-                          }
-                          const proposed =
-                            parseInt((e.target as HTMLInputElement).value) /
-                            100;
-                          const { prod, road, research } =
-                            this._applyTripleInvestmentConstraint(
-                              "prod",
-                              proposed,
-                            );
-
-                          const prodChanged = prod !== this.investmentRate;
-                          const roadChanged = road !== this._roadInvestmentRate;
-                          const researchChanged =
-                            research !== this._researchInvestmentRate;
-
-                          this.investmentRate = prod;
-                          this._roadInvestmentRate = road;
-                          this._researchInvestmentRate = research;
-
-                          if (prodChanged)
-                            this.onInvestmentRateChange(this.investmentRate);
-                          if (roadChanged)
-                            this.onRoadInvestmentChange(
-                              this._roadInvestmentRate,
-                            );
-                          if (researchChanged)
-                            this.onResearchInvestmentChange(
-                              this._researchInvestmentRate,
-                            );
-
-                          localStorage.setItem(
-                            "settings.investmentRate",
-                            this.investmentRate.toString(),
-                          );
-                          localStorage.setItem(
-                            "settings.roadInvestmentRate",
-                            this._roadInvestmentRate.toString(),
-                          );
-                          localStorage.setItem(
-                            "settings.researchInvestmentRate",
-                            this._researchInvestmentRate.toString(),
-                          );
-                          // Snap slider back to the effective value in case constraint blocked change
-                          (e.target as HTMLInputElement).value = (
-                            this.investmentRate * 100
-                          ).toString();
+                          const input = e.target as HTMLInputElement;
+                          const proposed = parseInt(input.value) / 100;
+                          this.applyInvestmentChange("prod", proposed);
+                          input.value = (this.investmentRate * 100).toString();
                         }}
                       />
                     </div>
@@ -1573,55 +1663,10 @@ export class ControlPanel2 extends LitElement implements Layer {
                           : ""}
                         @input=${(e: Event) => {
                           if (!hasRoads) return;
-                          if (this._lockRoad) {
-                            (e.target as HTMLInputElement).value = (
-                              this._roadInvestmentRate * 100
-                            ).toString();
-                            return;
-                          }
-                          const proposed =
-                            parseInt((e.target as HTMLInputElement).value) /
-                            100;
-                          const { prod, road, research } =
-                            this._applyTripleInvestmentConstraint(
-                              "road",
-                              proposed,
-                            );
-
-                          const prodChanged = prod !== this.investmentRate;
-                          const roadChanged = road !== this._roadInvestmentRate;
-                          const researchChanged =
-                            research !== this._researchInvestmentRate;
-
-                          this.investmentRate = prod;
-                          this._roadInvestmentRate = road;
-                          this._researchInvestmentRate = research;
-
-                          if (roadChanged)
-                            this.onRoadInvestmentChange(
-                              this._roadInvestmentRate,
-                            );
-                          if (prodChanged)
-                            this.onInvestmentRateChange(this.investmentRate);
-                          if (researchChanged)
-                            this.onResearchInvestmentChange(
-                              this._researchInvestmentRate,
-                            );
-
-                          localStorage.setItem(
-                            "settings.roadInvestmentRate",
-                            this._roadInvestmentRate.toString(),
-                          );
-                          localStorage.setItem(
-                            "settings.investmentRate",
-                            this.investmentRate.toString(),
-                          );
-                          localStorage.setItem(
-                            "settings.researchInvestmentRate",
-                            this._researchInvestmentRate.toString(),
-                          );
-                          // Snap slider to effective value
-                          (e.target as HTMLInputElement).value = (
+                          const input = e.target as HTMLInputElement;
+                          const proposed = parseInt(input.value) / 100;
+                          this.applyInvestmentChange("road", proposed);
+                          input.value = (
                             this._roadInvestmentRate * 100
                           ).toString();
                         }}
@@ -1629,8 +1674,12 @@ export class ControlPanel2 extends LitElement implements Layer {
                           ._lockRoad && hasRoads
                           ? "slider-locked"
                           : ""}"
-                        @dblclick=${() =>
-                          hasRoads && (this._lockRoad = !this._lockRoad)}
+                        @dblclick=${() => {
+                          if (hasRoads) {
+                            this._lockRoad = !this._lockRoad;
+                            this.emitInvestmentSync();
+                          }
+                        }}
                       />
                     </div>
                     <div
@@ -1699,55 +1748,10 @@ export class ControlPanel2 extends LitElement implements Layer {
                           this._researchInvestmentRate * 100
                         ).toString()}
                         @input=${(e: Event) => {
-                          if (this._lockResearch) {
-                            (e.target as HTMLInputElement).value = (
-                              this._researchInvestmentRate * 100
-                            ).toString();
-                            return;
-                          }
-                          const proposed =
-                            parseInt((e.target as HTMLInputElement).value) /
-                            100;
-                          const { prod, road, research } =
-                            this._applyTripleInvestmentConstraint(
-                              "research",
-                              proposed,
-                            );
-
-                          const prodChanged = prod !== this.investmentRate;
-                          const roadChanged = road !== this._roadInvestmentRate;
-                          const researchChanged =
-                            research !== this._researchInvestmentRate;
-
-                          this.investmentRate = prod;
-                          this._roadInvestmentRate = road;
-                          this._researchInvestmentRate = research;
-
-                          if (prodChanged)
-                            this.onInvestmentRateChange(this.investmentRate);
-                          if (roadChanged)
-                            this.onRoadInvestmentChange(
-                              this._roadInvestmentRate,
-                            );
-                          if (researchChanged)
-                            this.onResearchInvestmentChange(
-                              this._researchInvestmentRate,
-                            );
-
-                          localStorage.setItem(
-                            "settings.investmentRate",
-                            this.investmentRate.toString(),
-                          );
-                          localStorage.setItem(
-                            "settings.roadInvestmentRate",
-                            this._roadInvestmentRate.toString(),
-                          );
-                          localStorage.setItem(
-                            "settings.researchInvestmentRate",
-                            this._researchInvestmentRate.toString(),
-                          );
-                          // Snap slider to effective value
-                          (e.target as HTMLInputElement).value = (
+                          const input = e.target as HTMLInputElement;
+                          const proposed = parseInt(input.value) / 100;
+                          this.applyInvestmentChange("research", proposed);
+                          input.value = (
                             this._researchInvestmentRate * 100
                           ).toString();
                         }}
@@ -1755,8 +1759,10 @@ export class ControlPanel2 extends LitElement implements Layer {
                           ._lockResearch
                           ? "slider-locked"
                           : ""}"
-                        @dblclick=${() =>
-                          (this._lockResearch = !this._lockResearch)}
+                        @dblclick=${() => {
+                          this._lockResearch = !this._lockResearch;
+                          this.emitInvestmentSync();
+                        }}
                       />
                     </div>
                   </div>

--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -9,7 +9,6 @@ import {
   UpgradeType,
 } from "../../../core/game/Game";
 import { GameView, PlayerView } from "../../../core/game/GameView";
-import { getTechNodes } from "../../../core/tech/ResearchTree";
 import { getTechMeta, RESEARCH_TECH_IDS } from "../../../core/tech/TechEffects";
 import {
   INVESTMENT_REQUEST_EVENT,
@@ -20,7 +19,6 @@ import {
 } from "../../events/InvestmentEvents";
 import { PlayerListChangedEvent } from "../../events/PlayerListChangedEvent";
 import { AttackRatioEvent } from "../../InputHandler";
-import "../../ResearchTreeModal";
 import {
   SendBomberIntentEvent,
   SendSetAutoBombingEvent,
@@ -46,9 +44,6 @@ export class ControlPanel2 extends LitElement implements Layer {
   private targetTroopRatio = 0.6;
 
   @state()
-  private currentTroopRatio = 0.6;
-
-  @state()
   private investmentRate: number = 0; // default to 0%
 
   @state()
@@ -69,28 +64,10 @@ export class ControlPanel2 extends LitElement implements Layer {
   private _population: number;
 
   @state()
-  private _maxPopulation: number;
-
-  @state()
-  private popRate: number;
-
-  @state()
-  private _hospitalReturns: number = 0;
-
-  @state()
-  private _troops: number;
-
-  @state()
-  private _workers: number;
-
-  @state()
   private _isVisible = false;
 
   @state()
   private isOpen = false;
-
-  @state()
-  private _manpower: number = 0;
 
   @state()
   private _gold: Gold;
@@ -101,21 +78,10 @@ export class ControlPanel2 extends LitElement implements Layer {
   @state()
   private _productivityGrowth: number;
 
-  @state()
-  private _goldPerSecond: Gold;
-
-  private _lastPopulationIncreaseRate: number;
-
-  private _popRateIsIncreasing: boolean = true;
-
   private init_: boolean = false;
 
   @state()
-  private activeTab: "Build" | "Attack" | "Economy" | "Research" | "Bombers" =
-    "Build";
-
-  @state()
-  private activeResearchTab: "Land" | "Water" | "Air" | "Economy" = "Land";
+  private activeTab: "Build" | "Attack" | "Economy" | "Bombers" = "Build";
 
   @state()
   private _lastAirfieldCount: number = 0;
@@ -268,7 +234,6 @@ export class ControlPanel2 extends LitElement implements Layer {
     this.uiState.investmentRate = this.investmentRate;
     this.init_ = true;
     this.uiState.attackRatio = this.attackRatio;
-    this.currentTroopRatio = this.targetTroopRatio;
 
     this.eventBus.on(AttackRatioEvent, (event: AttackRatioEvent) => {
       let newAttackRatio =
@@ -346,39 +311,10 @@ export class ControlPanel2 extends LitElement implements Layer {
       return;
     }
 
-    const popIncreaseRate = player.population() - this._population;
-    if (this.game.ticks() % 5 === 0) {
-      this._popRateIsIncreasing =
-        popIncreaseRate >= this._lastPopulationIncreaseRate;
-      this._lastPopulationIncreaseRate = popIncreaseRate;
-    }
-
     this._population = player.population();
-    this._maxPopulation = this.game.config().maxPopulation(player);
-    this._hospitalReturns = player.hospitalReturns() * 10;
     this._gold = player.gold();
     this._productivity = player.productivity();
     this._productivityGrowth = player.productivityGrowthPerMinute();
-    this._troops = player.troops();
-    this._workers = player.workers();
-    this.popRate = this.game.config().populationIncreaseRate(player) * 10;
-    // Compute net gold/sec consistent with server logic
-    {
-      const grossPerTick = this.game.config().grossGoldAdditionRate(player);
-      const prod = player.investmentRate?.() ?? 0;
-      const hasRoads = player.hasUpgrade(UpgradeType.Roads);
-      const effectiveRoad = hasRoads ? this._roadInvestmentRate : 0;
-      let totalInvest = prod + effectiveRoad + this._researchInvestmentRate;
-      const hasTreasury = (this._gold ?? 0n) > 0n;
-      const maxTotal = hasTreasury ? 1.1 : 1.0;
-      if (!Number.isFinite(totalInvest)) totalInvest = 0;
-      if (totalInvest > maxTotal) totalInvest = maxTotal;
-      let netPerTickDouble = grossPerTick * (1 - totalInvest);
-      if (!Number.isFinite(netPerTickDouble)) netPerTickDouble = 0;
-      const netPerTick = BigInt(Math.floor(netPerTickDouble));
-      this._goldPerSecond = netPerTick * 10n;
-    }
-
     this.investmentRate = player.investmentRate();
     // If Roads are not researched, force road investment to 0 and persist
     const hasRoadsUpgrade = player.hasUpgrade(UpgradeType.Roads);
@@ -478,7 +414,6 @@ export class ControlPanel2 extends LitElement implements Layer {
         }
       }
     }
-    this.currentTroopRatio = player.troops() / player.population();
 
     // Track relevant state for dynamic updates
     const currentAirfieldCount = player.units(UnitType.Airfield).length;
@@ -711,17 +646,8 @@ export class ControlPanel2 extends LitElement implements Layer {
     this.requestUpdate();
   }
 
-  targetTroops(): number {
-    return this._manpower * this.targetTroopRatio;
-  }
-
   onTroopChange(newRatio: number) {
     this.eventBus.emit(new SendSetTargetTroopRatioEvent(newRatio));
-  }
-
-  delta(): number {
-    const d = this._population - this.targetTroops();
-    return d;
   }
 
   private playerHasRoadsUpgrade(): boolean {
@@ -920,9 +846,7 @@ export class ControlPanel2 extends LitElement implements Layer {
     this.uiState.multibuildEnabled = checkbox.checked;
   }
 
-  private _changeTab(
-    tab: "Build" | "Attack" | "Economy" | "Research" | "Bombers",
-  ) {
+  private _changeTab(tab: "Build" | "Attack" | "Economy" | "Bombers") {
     this.activeTab = tab;
     if (this.uiState.pendingBuildUnitType) {
       this.uiState.pendingBuildUnitType = null;
@@ -936,7 +860,6 @@ export class ControlPanel2 extends LitElement implements Layer {
 
     const player = this.game.myPlayer();
     const hasRoads = player?.hasUpgrade(UpgradeType.Roads) ?? false;
-    // Research tab has been simplified; upgrade buttons and sub-tabs removed.
 
     return html`
       <style>
@@ -1002,7 +925,7 @@ export class ControlPanel2 extends LitElement implements Layer {
           box-shadow: none;
         }
 
-        /* Top-level ControlPanel2 tabs (Build/Attack/Economy/Research/Bombers) */
+        /* Top-level ControlPanel2 tabs (Build/Attack/Economy/Bombers) */
         .cp2-tab {
           color: #c9dbff;
           border: 1px solid #0e1a33;
@@ -1024,78 +947,6 @@ export class ControlPanel2 extends LitElement implements Layer {
           color: #e3edff;
           border-color: #27476e;
           box-shadow: 0 0 0 1px rgba(39, 71, 110, 0.35) inset;
-        }
-
-        .research-tabs {
-          display: flex;
-          margin-top: auto;
-          /* submarine palette divider */
-          border-top: 1px solid #27476e;
-        }
-
-        .research-tab {
-          flex-grow: 1;
-          padding: 8px 0;
-          text-align: center;
-          cursor: pointer;
-          /* submarine palette button base */
-          border: 1px solid #0e1a33;
-          border-top: none;
-          background-color: #0b1220;
-          color: #c9dbff;
-          box-shadow: inset 0px 2px 5px rgba(0, 0, 0, 0.4);
-        }
-
-        .research-tab:hover:not(.active) {
-          background-color: #162544;
-          color: #e3edff;
-        }
-
-        .research-tab.active {
-          background-color: #182742;
-          color: #e3edff;
-          border-color: #27476e;
-          border-bottom-color: transparent;
-          box-shadow: 0px -2px 5px rgba(0, 0, 0, 0.2);
-          position: relative;
-          top: -1px;
-          border-radius: 6px 6px 0 0;
-        }
-
-        /* Dedicated Research Tree button aligned to submarine palette */
-        .research-button {
-          background-color: #183152; /* slightly brighter than panel */
-          color: #e3edff;
-          border: 1px solid #27476e;
-          padding: 4px 10px;
-          text-transform: uppercase;
-          font-size: 12px;
-          font-family: monospace;
-          transition:
-            background-color 0.15s ease-in-out,
-            box-shadow 0.15s ease-in-out,
-            border-color 0.15s ease-in-out;
-          box-shadow: 0 0 0 1px rgba(39, 71, 110, 0.35) inset;
-          border-radius: 6px;
-        }
-        .research-button:hover {
-          background-color: #1d3a60;
-          border-color: #32629b;
-          box-shadow: 0 0 0 2px rgba(50, 98, 155, 0.45) inset;
-        }
-
-        /* Simple progress bar for research items */
-        .progress-track {
-          width: 100%;
-          height: 6px;
-          background: rgba(39, 71, 110, 0.25);
-          border: 1px solid rgba(39, 71, 110, 0.35);
-          border-radius: 6px;
-          overflow: hidden;
-        }
-        .progress-fill {
-          height: 100%;
-          background: linear-gradient(90deg, #60a5fa, #3b82f6);
         }
 
         input[type="range"] {
@@ -1214,15 +1065,6 @@ export class ControlPanel2 extends LitElement implements Layer {
             @click=${() => this._changeTab("Economy")}
           >
             Economy
-          </button>
-          <button
-            class="py-2 px-4 text-center font-ocr uppercase cp2-tab ${this
-              .activeTab === "Research"
-              ? "active"
-              : ""}"
-            @click=${() => this._changeTab("Research")}
-          >
-            Research
           </button>
           ${this._hasAirfields
             ? html`
@@ -1809,100 +1651,6 @@ export class ControlPanel2 extends LitElement implements Layer {
                   </div>
                 </div>
               `
-            : ""}
-          ${this.activeTab === "Research"
-            ? (() => {
-                const me = this.game?.myPlayer?.();
-                const techs = getTechNodes();
-                const researched = new Set<string>();
-                if (me) {
-                  for (const t of techs)
-                    if (me.hasResearchedTech(t.id)) researched.add(t.id);
-                }
-                const active = me
-                  ? techs
-                      .map((t) => {
-                        const beakers = me.researchBeakers?.(t.id) ?? 0;
-                        const cost = t.cost || 1;
-                        const pct = Math.max(
-                          0,
-                          Math.min(100, Math.floor((beakers / cost) * 100)),
-                        );
-                        return {
-                          id: t.id,
-                          name: t.name,
-                          beakers,
-                          cost,
-                          pct,
-                          isDone: researched.has(t.id),
-                        };
-                      })
-                      .filter((x) => x.beakers > 0 && !x.isDone)
-                      .sort((a, b) => b.pct - a.pct)
-                  : [];
-                const priorityId = me?.researchPriorityTech?.() ?? null;
-                const priorityName = priorityId
-                  ? getTechMeta(priorityId, { strict: false }).name
-                  : "None";
-                return html`<div class="flex h-full flex-col">
-                  <h3 class="military-heading mb-2">Research</h3>
-                  <div class="mb-2 military-label" style="font-size: 11px;">
-                    Current Priority:
-                    <span class="font-semibold">${priorityName}</span>
-                  </div>
-                  <div
-                    class="grid grid-cols-2 gap-x-3 gap-y-1 pr-1"
-                    style="font-size: 11px;"
-                  >
-                    ${active.length === 0
-                      ? html`<div class="opacity-70 col-span-2">
-                          No active research yet. Set a priority in the Research
-                          Tree or allocate Research investment.
-                        </div>`
-                      : (() => {
-                          const n = active.length;
-                          const leftCount = Math.ceil(n / 2);
-                          const remapped: typeof active = [];
-                          for (let i = 0; i < leftCount; i++) {
-                            remapped.push(active[i]);
-                            if (i + leftCount < n)
-                              remapped.push(active[i + leftCount]);
-                          }
-                          return remapped.map(
-                            (it) =>
-                              html`<div
-                                class="flex items-center justify-between"
-                                title="${it.name}"
-                              >
-                                <div class="truncate pr-2">${it.name}</div>
-                                <div class="opacity-80" translate="no">
-                                  ${it.beakers.toLocaleString()} /
-                                  ${it.cost.toLocaleString()} (${it.pct}%)
-                                </div>
-                              </div>`,
-                          );
-                        })()}
-                  </div>
-                  <div class="mt-auto flex justify-end pt-2">
-                    <button
-                      class="research-button"
-                      title="Open Research Tree"
-                      @click=${() => {
-                        const modal = document.querySelector(
-                          "research-tree-modal",
-                        ) as any;
-                        if (modal) {
-                          modal.game = this.game;
-                          modal.eventBus = this.eventBus;
-                          modal.open();
-                        }
-                      }}
-                    >
-                      Research Tree
-                    </button>
-                  </div>
-                </div>`;
-              })()
             : ""}
         </div>
       </div>

--- a/src/client/graphics/layers/ResearchToggleButton.ts
+++ b/src/client/graphics/layers/ResearchToggleButton.ts
@@ -1,0 +1,152 @@
+import { html, LitElement } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { EventBus } from "../../../core/EventBus";
+import { GameView } from "../../../core/game/GameView";
+import "../../ResearchTreeModal";
+import type { ResearchTreeModal } from "../../ResearchTreeModal";
+import { Layer } from "./Layer";
+
+@customElement("research-toggle-button")
+export class ResearchToggleButton extends LitElement implements Layer {
+  public game: GameView;
+  public eventBus: EventBus;
+
+  @state()
+  private _isVisible = false;
+
+  @state()
+  private _isModalOpen = false;
+
+  private modalRef: ResearchTreeModal | null = null;
+
+  createRenderRoot() {
+    return this; // inherit global styles / Tailwind scale adjustments
+  }
+
+  init() {
+    this.modalRef = this.lookupModal();
+    this.updateModalState();
+  }
+
+  tick() {
+    const player = this.game?.myPlayer?.();
+    const shouldShow = Boolean(
+      player && player.isAlive() && !this.game.inSpawnPhase(),
+    );
+    if (shouldShow !== this._isVisible) {
+      this._isVisible = shouldShow;
+      this.requestUpdate();
+    }
+    this.updateModalState();
+  }
+
+  shouldTransform(): boolean {
+    return false;
+  }
+
+  private lookupModal(): ResearchTreeModal | null {
+    return document.querySelector(
+      "research-tree-modal",
+    ) as ResearchTreeModal | null;
+  }
+
+  private updateModalState() {
+    const modal = this.modalRef ?? this.lookupModal();
+    if (!modal) {
+      this._isModalOpen = false;
+      return;
+    }
+    this.modalRef = modal;
+    const modalShell = modal.shadowRoot?.querySelector("o-modal") as
+      | (HTMLElement & { isModalOpen?: boolean })
+      | null;
+    const isOpen = Boolean(modalShell?.isModalOpen);
+    if (isOpen !== this._isModalOpen) {
+      this._isModalOpen = isOpen;
+      this.requestUpdate();
+    }
+  }
+
+  private toggleModal = () => {
+    const modal = this.modalRef ?? this.lookupModal();
+    if (!modal) return;
+    modal.game = this.game;
+    modal.eventBus = this.eventBus;
+    if (this._isModalOpen) {
+      modal.close();
+    } else {
+      modal.open();
+    }
+    this._isModalOpen = !this._isModalOpen;
+  };
+
+  render() {
+    if (!this._isVisible) return html``;
+
+    return html`
+      <style>
+        .research-vertical-button {
+          position: fixed;
+          left: 0;
+          top: 50%;
+          transform: translateY(-50%);
+          z-index: 10050;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 4px;
+          padding: 14px 10px;
+          border: 2px solid #0e1a33;
+          border-left: none;
+          border-radius: 0 6px 6px 0;
+          text-transform: uppercase;
+          letter-spacing: 1px;
+          font-family: "Oswald", sans-serif;
+          background: linear-gradient(
+            180deg,
+            rgba(11, 18, 32, 0.96),
+            rgba(24, 39, 66, 0.96)
+          );
+          color: #e3edff;
+          cursor: pointer;
+          box-shadow:
+            inset 0 0 8px rgba(255, 255, 255, 0.08),
+            4px 0 12px rgba(0, 0, 0, 0.45);
+          transition:
+            transform 120ms ease,
+            box-shadow 120ms ease,
+            background 120ms ease;
+        }
+        .research-vertical-button span {
+          display: block;
+          font-size: 14px;
+          line-height: 1.1;
+        }
+        .research-vertical-button:hover {
+          transform: translateY(-50%) scale(1.05);
+          box-shadow:
+            inset 0 0 12px rgba(255, 255, 255, 0.12),
+            8px 0 16px rgba(0, 0, 0, 0.6);
+        }
+        .research-vertical-button.open {
+          background: linear-gradient(
+            180deg,
+            rgba(47, 74, 122, 0.96),
+            rgba(25, 48, 88, 0.96)
+          );
+          border-color: #27476e;
+        }
+      </style>
+      <button
+        type="button"
+        class="research-vertical-button ${this._isModalOpen ? "open" : ""}"
+        aria-label="Toggle Research Tree"
+        @click=${this.toggleModal}
+      >
+        ${["R", "E", "S", "E", "A", "R", "C", "H"].map(
+          (letter) => html`<span>${letter}</span>`,
+        )}
+      </button>
+    `;
+  }
+}

--- a/src/client/graphics/layers/TechUnlockNotification.ts
+++ b/src/client/graphics/layers/TechUnlockNotification.ts
@@ -1,0 +1,271 @@
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { EventBus } from "../../../core/EventBus";
+import { PlayerID } from "../../../core/game/Game";
+import {
+  GameUpdateType,
+  type PlayerUpdate,
+} from "../../../core/game/GameUpdates";
+import { GameView } from "../../../core/game/GameView";
+import { getTechNodes } from "../../../core/tech/ResearchTree";
+import { getTechMeta } from "../../../core/tech/TechEffects";
+import { Layer } from "./Layer";
+
+type TechNotificationPayload = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+const AUTO_DISMISS_DELAY_MS = 5000;
+const EXIT_ANIMATION_MS = 200;
+
+@customElement("tech-unlock-notification")
+export class TechUnlockNotification extends LitElement implements Layer {
+  @property({ attribute: false })
+  public game!: GameView;
+
+  @property({ attribute: false })
+  public eventBus!: EventBus;
+
+  @state()
+  private current: TechNotificationPayload | null = null;
+
+  @state()
+  private isVisible = false;
+
+  private queue: TechNotificationPayload[] = [];
+  private seenTechs = new Set<string>();
+  private activePlayerId: PlayerID | null = null;
+  private dismissTimer: number | null = null;
+  private exitTimer: number | null = null;
+  private allTechIds = new Set(getTechNodes().map((t) => t.id));
+
+  createRenderRoot() {
+    return this;
+  }
+
+  init() {
+    this.seedFromPlayer();
+  }
+
+  shouldTransform(): boolean {
+    return false;
+  }
+
+  tick() {
+    const player = this.game.myPlayer();
+    if (!player || !player.isAlive()) {
+      if (this.activePlayerId !== null) {
+        this.resetState();
+      }
+      return;
+    }
+
+    if (player.id() !== this.activePlayerId) {
+      this.activePlayerId = player.id();
+      this.seedFromPlayer();
+    }
+
+    const updates = this.game.updatesSinceLastTick();
+    const playerUpdates =
+      (updates?.[GameUpdateType.Player] as PlayerUpdate[]) ?? [];
+    if (!playerUpdates.length) return;
+
+    for (const update of playerUpdates) {
+      if (update.id !== player.id()) continue;
+      if (!update.researchTreeTechs) continue;
+      this.handleResearchUpdate(update.researchTreeTechs);
+    }
+  }
+
+  private handleResearchUpdate(updatedTechs: string[]) {
+    const filtered = updatedTechs.filter((id) => this.allTechIds.has(id));
+    for (const techId of filtered) {
+      if (this.seenTechs.has(techId)) continue;
+      const meta = getTechMeta(techId, { strict: false });
+      if (!meta) continue;
+      this.seenTechs.add(techId);
+      this.enqueue({
+        id: techId,
+        name: meta.name ?? techId,
+        description: meta.description ?? "",
+      });
+    }
+    for (const techId of filtered) this.seenTechs.add(techId);
+  }
+
+  private seedFromPlayer() {
+    this.queue = [];
+    this.clearTimers();
+    this.current = null;
+    this.isVisible = false;
+    this.seenTechs.clear();
+    const player = this.game.myPlayer();
+    if (!player) return;
+    for (const techId of this.allTechIds) {
+      if (player.hasResearchedTech(techId)) {
+        this.seenTechs.add(techId);
+      }
+    }
+  }
+
+  private resetState() {
+    this.activePlayerId = null;
+    this.seenTechs.clear();
+    this.queue = [];
+    this.clearTimers();
+    this.current = null;
+    this.isVisible = false;
+  }
+
+  private enqueue(payload: TechNotificationPayload) {
+    this.queue.push(payload);
+    if (!this.current) {
+      this.showNext();
+    }
+  }
+
+  private showNext() {
+    const next = this.queue.shift() ?? null;
+    this.current = next;
+    if (!next) {
+      this.isVisible = false;
+      return;
+    }
+    this.isVisible = true;
+    this.clearDismissTimer();
+    this.dismissTimer = window.setTimeout(
+      () => this.handleAutoDismiss(),
+      AUTO_DISMISS_DELAY_MS,
+    );
+  }
+
+  private handleAutoDismiss() {
+    this.dismiss();
+  }
+
+  private dismiss = () => {
+    if (!this.current) return;
+    this.isVisible = false;
+    this.clearDismissTimer();
+    this.clearExitTimer();
+    this.exitTimer = window.setTimeout(() => {
+      this.current = null;
+      this.showNext();
+    }, EXIT_ANIMATION_MS);
+  };
+
+  private clearTimers() {
+    this.clearDismissTimer();
+    this.clearExitTimer();
+  }
+
+  private clearDismissTimer() {
+    if (this.dismissTimer !== null) {
+      window.clearTimeout(this.dismissTimer);
+      this.dismissTimer = null;
+    }
+  }
+
+  private clearExitTimer() {
+    if (this.exitTimer !== null) {
+      window.clearTimeout(this.exitTimer);
+      this.exitTimer = null;
+    }
+  }
+
+  render() {
+    const visible = this.isVisible && this.current !== null;
+    return html`
+      <style>
+        .tech-toast {
+          position: fixed;
+          left: 36px;
+          top: 50%;
+          transform: translateY(-50%);
+          width: min(320px, 90vw);
+          background: linear-gradient(
+            180deg,
+            rgba(11, 18, 32, 0.95),
+            rgba(24, 39, 66, 0.95)
+          );
+          border: 2px solid rgba(14, 26, 51, 0.9);
+          border-radius: 8px;
+          padding: 12px 16px;
+          color: #e3edff;
+          font-family: "Oswald", sans-serif;
+          box-shadow:
+            inset 0 0 12px rgba(255, 255, 255, 0.08),
+            8px 12px 24px rgba(0, 0, 0, 0.55);
+          transition:
+            transform 200ms ease,
+            opacity 200ms ease;
+          opacity: 0;
+          transform: translate(-120%, -50%);
+          z-index: 10040;
+          cursor: pointer;
+        }
+        .tech-toast.visible {
+          transform: translate(0, -50%);
+          opacity: 1;
+        }
+        .tech-toast__header {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          margin-bottom: 8px;
+        }
+        .tech-toast__label {
+          font-size: 12px;
+          letter-spacing: 0.2em;
+          text-transform: uppercase;
+          color: #fcd34d;
+          animation: pulse 1.25s ease-in-out infinite;
+        }
+        .tech-toast__title {
+          font-size: 20px;
+          line-height: 1.1;
+          text-transform: uppercase;
+        }
+        .tech-toast__body {
+          font-size: 13px;
+          font-family: "Roboto Mono", monospace;
+          color: rgba(227, 237, 255, 0.85);
+          line-height: 1.4;
+          white-space: pre-line;
+        }
+        @keyframes pulse {
+          0% {
+            opacity: 0.7;
+            text-shadow: 0 0 4px rgba(252, 211, 77, 0.4);
+          }
+          50% {
+            opacity: 1;
+            text-shadow: 0 0 12px rgba(252, 211, 77, 0.8);
+          }
+          100% {
+            opacity: 0.7;
+            text-shadow: 0 0 4px rgba(252, 211, 77, 0.4);
+          }
+        }
+      </style>
+      <div
+        class="tech-toast ${visible ? "visible" : ""}"
+        role="status"
+        aria-live="polite"
+        @click=${this.dismiss}
+      >
+        ${this.current
+          ? html`
+              <div class="tech-toast__header">
+                <span class="tech-toast__label">Tech unlocked</span>
+                <span class="tech-toast__title">${this.current.name}</span>
+              </div>
+              <p class="tech-toast__body">${this.current.description}</p>
+            `
+          : null}
+      </div>
+    `;
+  }
+}

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -360,6 +360,7 @@
     <player-panel></player-panel>
     <help-modal></help-modal>
     <sound-button></sound-button>
+    <research-toggle-button></research-toggle-button>
     <alert-frame></alert-frame>
     <chat-modal></chat-modal>
     <user-setting></user-setting>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -362,6 +362,7 @@
     <sound-button></sound-button>
     <research-toggle-button></research-toggle-button>
     <alert-frame></alert-frame>
+    <tech-unlock-notification></tech-unlock-notification>
     <chat-modal></chat-modal>
     <user-setting></user-setting>
     <multi-tab-modal></multi-tab-modal>


### PR DESCRIPTION
## Note:
Build on top of https://github.com/1brucben/Terratomic/pull/63, https://github.com/1brucben/Terratomic/pull/64,  https://github.com/1brucben/Terratomic/pull/65, https://github.com/1brucben/Terratomic/pull/66 and https://github.com/1brucben/Terratomic/pull/67

## Description:

This Pull Request introduces a significant overhaul of the research tree user interface, transforming it into a more organized and user-friendly experience. It refactors existing components, adds new interactive elements, and enhances visual feedback for technology unlocks. The primary goal is to improve navigation, provide more immediate information, and streamline player interaction with the research system.

## Visual and Functional Changes

*   **Tabbed Research Tree Interface:** The research tree modal (`ResearchTreeModal.ts`) has been redesigned from a wide, multi-column layout into a tabbed interface. Players can now easily navigate between different research categories (Land, Sea, Air, Nuclear, Economy) and an "Overview" tab.

<img width="1948" height="736" alt="image" src="https://github.com/user-attachments/assets/82b2e0f5-32a2-4962-9dcd-15be7d0ff1c2" />

*   **Inline Investment Sliders:** Road and Research investment sliders are now directly integrated into the `ResearchTreeModal`, allowing players to manage their investment rates without leaving the research view. These sliders are synchronized with the main control panel.

<img width="1907" height="123" alt="image" src="https://github.com/user-attachments/assets/70247933-9a3e-4390-8f46-0533fef84058" />

*   **Dedicated Vertical Research Button:** A new, fixed vertical button labeled "RESEARCH" has been added to the middle-left edge of the screen. This button provides a quick and consistent way to open and close the research tree modal.

<img width="1034" height="799" alt="image" src="https://github.com/user-attachments/assets/15dc19ac-b13a-4dd3-8071-65c3758b7d08" />

<img width="2558" height="1222" alt="image" src="https://github.com/user-attachments/assets/0119b1b3-69de-416b-95f9-f9ebeb18145c" />

*   **Tech Unlock Notifications:** Upon unlocking a new technology, players will receive a clear visual notification that slides out from the vertical research button. This notification displays the tech's name and description, features a subtle flashing header, and automatically dismisses after 5 seconds or upon user click. Notifications are queued to prevent overlap.

<img width="601" height="540" alt="image" src="https://github.com/user-attachments/assets/3a7f54f4-ef0e-4585-b6f0-5f2fab088928" />

*   **Research Overview with Progress:** The "All" tab in the research tree has been renamed to "Overview" and now displays inline completion percentages for each technology, providing players with a quick glance at their research progress.

<img width="1728" height="604" alt="image" src="https://github.com/user-attachments/assets/bbc5ebb7-2356-4d58-8d6a-a4e513a039ed" />

*   **Inline Tech Descriptions:** Each research card within the tree now directly displays its description, with text wrapping and scrolling for longer descriptions, eliminating the need to hover for basic information.

<img width="705" height="392" alt="image" src="https://github.com/user-attachments/assets/65b655fb-5ec1-4258-ae19-d22c47e5b7d9" />

*   **Removed In-Panel Research Tab:** The redundant "Research" tab and its associated button have been removed from the main `ControlPanel2` to centralize research access through the new dedicated vertical button.

<img width="695" height="278" alt="image" src="https://github.com/user-attachments/assets/0aca10da-dc3f-4c0b-9941-0ff2cf6cb9e0" />


## Technical Description

This PR involves several key architectural and component-level changes:

*   **`ResearchTreeModal.ts` Refactoring:**
    *   Implemented a tab-based rendering system to categorize and display research nodes.
    *   Integrated new state management for active tabs and investment rates.
    *   Updated rendering logic to display inline tech descriptions and completion percentages.
    *   Modified tooltip anchoring for research cards.
*   **Event-Driven Investment Management:**
    *   Introduced `src/client/events/InvestmentEvents.ts` to define custom events (`investment-sync`, `investment-request-change`) for decoupled communication between investment sliders.
    *   `ControlPanel2.ts` was refactored to centralize investment logic (`applyInvestmentChange`, `commitInvestmentRates`) and now dispatches/listens to these events.
    *   `ResearchTreeModal.ts` now listens for `investment-sync` events to keep its sliders updated and dispatches `investment-request-change` events when its sliders are manipulated.
*   **New `ResearchToggleButton.ts` Component:**
    *   A new LitElement component was created to render the fixed vertical "RESEARCH" button.
    *   It integrates with `GameRenderer` and `index.html` to ensure proper placement and access to game state/event bus.
    *   Manages the open/close state of the `ResearchTreeModal` directly.
    *   Its visibility is tied to the player's spawn status.
*   **New `TechUnlockNotification.ts` Component:**
    *   A new LitElement component responsible for rendering and managing tech unlock notifications.
    *   Subscribes to player updates to detect newly researched technologies.
    *   Implements a queuing mechanism for notifications to ensure they display one by one.
    *   Handles animation (slide-out/in), auto-dismissal, and click-to-dismiss functionality.
    *   Styling is aligned with `ControlPanel2` for consistency.
*   **`ControlPanel2.ts` Cleanup:**
    *   Removed the previous "Research" tab and its associated rendering logic and state, streamlining the main control panel.
    *   Removed the `getTechNodes` import as it's no longer needed in this component.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
