### PR TITLE
Fix PlayerInfoOverlay: Move team label to header section to prevent overflow"

### DIFF
--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -238,7 +238,7 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
 
     return html`
       <div class="flex flex-col p-2 min-w-max">
-        <!-- Box 0: Name, Relation, Type -->
+        <!-- Box 0: Name, Relation, Type, Team -->
         <div
           class="flex justify-center items-center gap-2 mb-2 w-full border border-gray-400 rounded p-1"
         >
@@ -265,6 +265,12 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
                   : ""}"
               >${playerType}</span
             >
+            ${player.team() !== null
+              ? html`<span class="ml-1"
+                  >· ${translateText("player_info_overlay.team")}
+                  ${player.team()}</span
+                >`
+              : ""}
           </div>
         </div>
 
@@ -276,12 +282,6 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
           >
             <!-- Box 2 Content -->
             <div class="flex items-center gap-2 text-sm opacity-80">
-              ${player.team() !== null
-                ? html`<span
-                    >${translateText("player_info_overlay.team")}:
-                    ${player.team()}</span
-                  >`
-                : ""}
               ${player.troops() >= 1
                 ? html`<span translate="no">
                     <img


### PR DESCRIPTION
## Description:

Fix PlayerInfoOverlay: Move team label to header section to prevent overflow"
Old:
<img width="624" height="170" alt="image" src="https://github.com/user-attachments/assets/21657050-ae9b-4ef2-9a17-2bc3a4ec4b80" />

New:
<img width="613" height="134" alt="image" src="https://github.com/user-attachments/assets/3f326124-d7af-4947-b036-5589ba258350" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
