### PR TITLE
Fix BuildMenu not showing submarine after tech unlock

### DIFF
--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -159,6 +159,9 @@ export class BuildMenu extends LitElement {
   @state()
   private hotkeyMap: Map<UnitType, string> = new Map();
 
+  @state()
+  private _lastSubmarineUpgradeState: boolean = false;
+
   // Recompute once after first render, and whenever relevant inputs change
   protected firstUpdated(): void {
     this.recomputeFilteredTable();
@@ -168,6 +171,18 @@ export class BuildMenu extends LitElement {
   protected updated(changed: Map<string, unknown>): void {
     if (changed.has("unitFilter") || changed.has("game")) {
       this.recomputeFilteredTable();
+    }
+  }
+
+  protected willUpdate(changed: Map<string, unknown>): void {
+    // Check if submarine upgrade state changed - lightweight check before render
+    const player = this.game?.myPlayer();
+    if (player) {
+      const hasSubUpgrade = player.hasUpgrade(UpgradeType.SubmarineResearch);
+      if (hasSubUpgrade !== this._lastSubmarineUpgradeState) {
+        this._lastSubmarineUpgradeState = hasSubUpgrade;
+        this.recomputeFilteredTable();
+      }
     }
   }
 


### PR DESCRIPTION
## Description:
- Add willUpdate() lifecycle hook to detect submarine upgrade state changes
- Track _lastSubmarineUpgradeState to trigger recomputeFilteredTable() only when needed
- Fixes issue where submarine purchase option wouldn't appear in Attack tab until tab switch
- Performant: only checks one boolean per render cycle, recomputes only on actual change
- Completes existing ControlPanel2.tick() requestUpdate() mechanism

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
