### PR TITLE
Refactor build controls: move upgrade button and add multi-build toggle

### DIFF
--- a/resources/images/MultiBuildIcon.svg
+++ b/resources/images/MultiBuildIcon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Bottom layer -->
+  <rect x="3" y="12" width="10" height="10" rx="1" opacity="0.4"/>
+  <!-- Middle layer -->
+  <rect x="7" y="8" width="10" height="10" rx="1" opacity="0.7"/>
+  <!-- Top layer -->
+  <rect x="11" y="4" width="10" height="10" rx="1"/>
+</svg>

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -15,12 +15,10 @@ import portIcon from "../../../../resources/images/PortIcon.svg";
 import samlauncherIcon from "../../../../resources/images/SamLauncherIconWhite.svg";
 import shieldIcon from "../../../../resources/images/ShieldIconWhite.svg";
 import submarineIcon from "../../../../resources/images/submarine.svg";
-import upgradeArrowIcon from "../../../../resources/images/UpgradeArrowIcon.svg";
 import { translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
 import { Gold, UnitType, UpgradeType } from "../../../core/game/Game";
 import { GameView } from "../../../core/game/GameView";
-import { ToggleUpgradeModeEvent } from "../../events/ToggleUpgradeModeEvent";
 import { CloseViewEvent } from "../../InputHandler";
 import { displayKey, renderNumber } from "../../Utils";
 import { UIState } from "../UIState";
@@ -417,58 +415,6 @@ export class BuildMenu extends LitElement {
       font-weight: bold;
       font-size: 10px;
     }
-    .upgrade-button-container {
-      align-self: flex-end;
-      margin: 8px 4px 4px auto;
-    }
-    .upgrade-button {
-      width: 70px;
-      height: 70px;
-      border: 2px solid var(--ui-panel-border);
-      background: var(--ui-primary);
-      color: var(--ui-text-accent);
-      border-radius: 6px;
-      box-shadow:
-        inset 0 0 10px rgba(0, 0, 0, 0.5),
-        0 2px 6px rgba(0, 0, 0, 0.4);
-      cursor: pointer;
-      transition: all 0.3s ease;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      gap: 4px;
-    }
-    .upgrade-button.selected {
-      border-color: var(--ui-secondary-hover);
-      box-shadow:
-        0 0 12px rgba(50, 98, 155, 0.75),
-        inset 0 0 12px rgba(0, 0, 0, 0.6);
-      background: var(--ui-secondary);
-      transform: scale(1.05);
-    }
-    .upgrade-button:hover {
-      background-color: var(--ui-secondary);
-      transform: scale(1.05);
-      border-color: var(--ui-secondary);
-    }
-    .upgrade-button:active {
-      background: linear-gradient(
-        to bottom,
-        var(--ui-secondary-hover),
-        var(--ui-secondary)
-      );
-      transform: scale(0.95);
-    }
-    .upgrade-icon {
-      width: 32px;
-      height: 32px;
-    }
-    .upgrade-label {
-      font-size: 11px;
-      font-weight: bold;
-      text-transform: lowercase;
-    }
   `;
 
   private canBuild(item: BuildItemDisplay): boolean {
@@ -588,22 +534,6 @@ export class BuildMenu extends LitElement {
             </div>
           `,
         )}
-        <div class="upgrade-button-container">
-          <button
-            class="upgrade-button ${this.uiState.upgradeMode ? "selected" : ""}"
-            title="Upgrade"
-            aria-label="Upgrade Mode"
-            @click=${() => {
-              const enabled = !this.uiState.upgradeMode;
-              this.uiState.upgradeMode = enabled;
-              this.eventBus.emit(new ToggleUpgradeModeEvent(enabled));
-              this.requestUpdate();
-            }}
-          >
-            <img class="upgrade-icon" src=${upgradeArrowIcon} alt="Upgrade" />
-            <span class="upgrade-label" translate="no">upgrade</span>
-          </button>
-        </div>
       </div>
     `;
   }

--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -1,5 +1,7 @@
 import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import multiBuildIcon from "../../../../resources/images/MultiBuildIcon.svg";
+import upgradeArrowIcon from "../../../../resources/images/UpgradeArrowIcon.svg";
 import { EventBus } from "../../../core/EventBus";
 import {
   Gold,
@@ -18,6 +20,7 @@ import {
   type InvestmentSyncDetail,
 } from "../../events/InvestmentEvents";
 import { PlayerListChangedEvent } from "../../events/PlayerListChangedEvent";
+import { ToggleUpgradeModeEvent } from "../../events/ToggleUpgradeModeEvent";
 import { AttackRatioEvent } from "../../InputHandler";
 import {
   SendBomberIntentEvent,
@@ -840,10 +843,15 @@ export class ControlPanel2 extends LitElement implements Layer {
     this._lastSelectedBomberTarget = select.value;
   }
 
-  private _handleMultibuildToggle(event: Event) {
-    const checkbox = event.target as HTMLInputElement;
-    this._multibuildEnabled = checkbox.checked;
-    this.uiState.multibuildEnabled = checkbox.checked;
+  private _handleMultibuildToggle() {
+    this._multibuildEnabled = !this._multibuildEnabled;
+    this.uiState.multibuildEnabled = this._multibuildEnabled;
+    // Disable upgrade mode if mass production is enabled
+    if (this._multibuildEnabled && this.uiState.upgradeMode) {
+      this.uiState.upgradeMode = false;
+      this.eventBus.emit(new ToggleUpgradeModeEvent(false));
+    }
+    this.requestUpdate();
   }
 
   private _changeTab(tab: "Build" | "Attack" | "Economy" | "Bombers") {
@@ -1228,20 +1236,52 @@ export class ControlPanel2 extends LitElement implements Layer {
             : ""}
           ${this.activeTab === "Build"
             ? html`
-                <div class="flex items-center mb-2">
-                  <input
-                    type="checkbox"
-                    id="multibuild-toggle"
-                    class="mr-2"
-                    .checked=${this._multibuildEnabled}
-                    @change=${this._handleMultibuildToggle}
-                  />
-                  <label for="multibuild-toggle" class="military-label"
-                    >Enable Mass Production</label
+                <div class="flex items-center mb-2 gap-4 ml-1">
+                  <button
+                    class="upgrade-structures-button ${this._multibuildEnabled
+                      ? "selected"
+                      : ""}"
+                    title="Multi-Build Structures"
+                    @click=${this._handleMultibuildToggle}
                   >
+                    <img
+                      class="upgrade-icon"
+                      src=${multiBuildIcon}
+                      alt="Multi-Build"
+                    />
+                    <span>Multi-Build Structures</span>
+                  </button>
+                  <button
+                    class="upgrade-structures-button ${this.uiState.upgradeMode
+                      ? "selected"
+                      : ""}"
+                    title="Upgrade Structures"
+                    @click=${() => {
+                      const enabled = !this.uiState.upgradeMode;
+                      this.uiState.upgradeMode = enabled;
+                      this.eventBus.emit(new ToggleUpgradeModeEvent(enabled));
+                      // Disable mass production if upgrade is enabled
+                      if (enabled && this._multibuildEnabled) {
+                        this._multibuildEnabled = false;
+                        this.uiState.multibuildEnabled = false;
+                      }
+                      // Clear pending build selection when upgrade is enabled
+                      if (enabled) {
+                        this.uiState.pendingBuildUnitType = null;
+                      }
+                      this.requestUpdate();
+                    }}
+                  >
+                    <img
+                      class="upgrade-icon"
+                      src=${upgradeArrowIcon}
+                      alt="Upgrade"
+                    />
+                    <span>Upgrade Structures</span>
+                  </button>
                 </div>
                 <build-menu
-                  style="width: 100%;"
+                  style="width: 100%; display: block;"
                   .game=${this.game}
                   .eventBus=${this.eventBus}
                   .uiState=${this.uiState}
@@ -1251,20 +1291,52 @@ export class ControlPanel2 extends LitElement implements Layer {
             : ""}
           ${this.activeTab === "Attack"
             ? html`
-                <div class="flex items-center mb-2">
-                  <input
-                    type="checkbox"
-                    id="multibuild-toggle"
-                    class="mr-2"
-                    .checked=${this._multibuildEnabled}
-                    @change=${this._handleMultibuildToggle}
-                  />
-                  <label for="multibuild-toggle" class="military-label"
-                    >Enable Mass Production</label
+                <div class="flex items-center mb-2 gap-4 ml-1">
+                  <button
+                    class="upgrade-structures-button ${this._multibuildEnabled
+                      ? "selected"
+                      : ""}"
+                    title="Multi-Build Structures"
+                    @click=${this._handleMultibuildToggle}
                   >
+                    <img
+                      class="upgrade-icon"
+                      src=${multiBuildIcon}
+                      alt="Multi-Build"
+                    />
+                    <span>Multi-Build Structures</span>
+                  </button>
+                  <button
+                    class="upgrade-structures-button ${this.uiState.upgradeMode
+                      ? "selected"
+                      : ""}"
+                    title="Upgrade structures"
+                    @click=${() => {
+                      const enabled = !this.uiState.upgradeMode;
+                      this.uiState.upgradeMode = enabled;
+                      this.eventBus.emit(new ToggleUpgradeModeEvent(enabled));
+                      // Disable mass production if upgrade is enabled
+                      if (enabled && this._multibuildEnabled) {
+                        this._multibuildEnabled = false;
+                        this.uiState.multibuildEnabled = false;
+                      }
+                      // Clear pending build selection when upgrade is enabled
+                      if (enabled) {
+                        this.uiState.pendingBuildUnitType = null;
+                      }
+                      this.requestUpdate();
+                    }}
+                  >
+                    <img
+                      class="upgrade-icon"
+                      src=${upgradeArrowIcon}
+                      alt="Upgrade"
+                    />
+                    <span>Upgrade structures</span>
+                  </button>
                 </div>
                 <build-menu
-                  style="width: 100%;"
+                  style="width: 100%; display: block;"
                   .game=${this.game}
                   .eventBus=${this.eventBus}
                   .uiState=${this.uiState}
@@ -1665,4 +1737,56 @@ export class ControlPanel2 extends LitElement implements Layer {
   createRenderRoot() {
     return this; // Disable shadow DOM to allow Tailwind styles
   }
+}
+
+// Add styles for upgrade button in global scope
+const style = document.createElement("style");
+style.textContent = `
+  .upgrade-structures-button {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 2px solid var(--ui-panel-border);
+    background: var(--ui-primary);
+    color: var(--ui-text-accent);
+    border-radius: 6px;
+    box-shadow:
+      inset 0 0 10px rgba(0, 0, 0, 0.5),
+      0 2px 6px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 13px;
+    font-weight: bold;
+    white-space: nowrap;
+  }
+  .upgrade-structures-button .upgrade-icon {
+    width: 18px;
+    height: 18px;
+  }
+  .upgrade-structures-button.selected {
+    border-color: var(--ui-secondary-hover);
+    box-shadow:
+      0 0 12px rgba(50, 98, 155, 0.75),
+      inset 0 0 12px rgba(0, 0, 0, 0.6);
+    background: var(--ui-secondary);
+    transform: scale(1.05);
+  }
+  .upgrade-structures-button:hover {
+    background-color: var(--ui-secondary);
+    transform: scale(1.05);
+    border-color: var(--ui-secondary);
+  }
+  .upgrade-structures-button:active {
+    background: linear-gradient(
+      to bottom,
+      var(--ui-secondary-hover),
+      var(--ui-secondary)
+    );
+    transform: scale(0.95);
+  }
+`;
+if (!document.head.querySelector("style[data-upgrade-button]")) {
+  style.setAttribute("data-upgrade-button", "true");
+  document.head.appendChild(style);
 }


### PR DESCRIPTION
## Description:

Refactor build controls: move upgrade button and add multi-build toggle
- Move upgrade button from BuildMenu to ControlPanel2 Build/Attack tabs
- Convert mass production checkbox to toggle button
- Implement mutual exclusivity between upgrade and multi-build modes
- Clear pending build selection when switching to upgrade mode
- Add new MultiBuildIcon.svg with stacked layers design
- Update button labels: 'Upgrade Structures' and 'Multi-Build Structures'
- Align buttons with build items grid (248px width = 2 items + gap)
- Add 4px left margin to match build item alignment
- Remove upgrade button and related CSS from BuildMenu
- Remove unused imports (upgradeArrowIcon, ToggleUpgradeModeEvent from BuildMenu)

<img width="702" height="294" alt="image" src="https://github.com/user-attachments/assets/bc8af231-c9e0-4a19-883d-7f5e90394c80" />

Fixes issue where enabling one mode while the other is active could lead to
unintended behavior (e.g., placing buildings when trying to upgrade)


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
