### PR TITLE
Range Overlay

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -111,6 +111,7 @@ export class CenterCameraEvent implements GameEvent {
 
 import { UnitType } from "../core/game/Game";
 import { GameView } from "../core/game/GameView";
+import { ToggleUpgradeModeEvent } from "./events/ToggleUpgradeModeEvent";
 import { TransformHandler } from "./graphics/TransformHandler";
 import { UIState } from "./graphics/UIState";
 import { BuildUnitIntentEvent } from "./Transport";
@@ -373,6 +374,11 @@ export class InputHandler {
 
     const unitType = buildHotkeys[code];
     if (unitType) {
+      // Any build action should disable upgrade mode and unhighlight its button
+      if (this.uiState.upgradeMode) {
+        this.uiState.upgradeMode = false;
+        this.eventBus.emit(new ToggleUpgradeModeEvent(false));
+      }
       const cell = this.transformHandler.screenToWorldCoordinates(
         this.lastPointerX,
         this.lastPointerY,
@@ -459,6 +465,11 @@ export class InputHandler {
       }
 
       const tile = this.game.ref(cell.x, cell.y);
+      // Placing a structure should also ensure upgrade mode is disabled
+      if (this.uiState.upgradeMode) {
+        this.uiState.upgradeMode = false;
+        this.eventBus.emit(new ToggleUpgradeModeEvent(false));
+      }
       this.eventBus.emit(
         new BuildUnitIntentEvent(this.uiState.pendingBuildUnitType, tile),
       );

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -23,6 +23,7 @@ import { OptionsMenu } from "./layers/OptionsMenu";
 import { PlayerInfoOverlay } from "./layers/PlayerInfoOverlay";
 import { PlayerPanel } from "./layers/PlayerPanel";
 import { RadialMenu } from "./layers/RadialMenu";
+import { RangeOverlayLayer } from "./layers/RangeOverlayLayer";
 import { ReplayPanel } from "./layers/ReplayPanel";
 import { ResearchToggleButton } from "./layers/ResearchToggleButton";
 import { RoadLayer } from "./layers/RoadLayer";
@@ -235,6 +236,8 @@ export function createRenderer(
     new TerritoryLayer(game, eventBus, transformHandler),
     new RoadLayer(game, transformHandler),
     new CargoTruckLayer(game, transformHandler),
+    // World-space ring overlay for Defense Posts/SAMs
+    new RangeOverlayLayer(game, eventBus, transformHandler),
     structureLayer,
     new UnitLayer(game, eventBus, transformHandler),
     new FxLayer(game),

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -237,7 +237,7 @@ export function createRenderer(
     new RoadLayer(game, transformHandler),
     new CargoTruckLayer(game, transformHandler),
     // World-space ring overlay for Defense Posts/SAMs
-    new RangeOverlayLayer(game, eventBus, transformHandler),
+    new RangeOverlayLayer(game, eventBus, transformHandler, uiState),
     structureLayer,
     new UnitLayer(game, eventBus, transformHandler),
     new FxLayer(game),

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -19,6 +19,7 @@ import { translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
 import { Gold, UnitType, UpgradeType } from "../../../core/game/Game";
 import { GameView } from "../../../core/game/GameView";
+import { ToggleUpgradeModeEvent } from "../../events/ToggleUpgradeModeEvent";
 import { CloseViewEvent } from "../../InputHandler";
 import { displayKey, renderNumber } from "../../Utils";
 import { UIState } from "../UIState";
@@ -462,6 +463,11 @@ export class BuildMenu extends LitElement {
   }
 
   public onBuildSelected = (item: BuildItemDisplay) => {
+    // Selecting a build item should exit upgrade mode and unhighlight the button
+    if (this.uiState?.upgradeMode) {
+      this.uiState.upgradeMode = false;
+      this.eventBus?.emit(new ToggleUpgradeModeEvent(false));
+    }
     if (this.uiState.pendingBuildUnitType === item.unitType) {
       this.uiState.pendingBuildUnitType = null;
     } else {

--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -142,7 +142,8 @@ export class RangeOverlayLayer implements Layer {
 
   private operationRadius(u: UnitView): number {
     if (u.type() === UnitType.DefensePost) {
-      return this.game.config().defensePostTargettingRange();
+      // Show the Defense Post's defensive aura radius, not its shell targeting range
+      return this.game.config().defensePostRange();
     }
     if (u.type() === UnitType.SAMLauncher) {
       const base = this.game.config().defaultSamRange();

--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -1,0 +1,164 @@
+import { Colord } from "colord";
+import { Theme } from "../../../core/configuration/Config";
+import { EventBus } from "../../../core/EventBus";
+import { Cell, UnitType } from "../../../core/game/Game";
+import { GameView, UnitView } from "../../../core/game/GameView";
+import { MouseOverEvent } from "../../InputHandler";
+import { TransformHandler } from "../TransformHandler";
+import { Layer } from "./Layer";
+
+/**
+ * RangeOverlayLayer
+ * Draws hover overlays for Defense Posts and SAM Launchers, visualizing their operation radii.
+ * - World-space rendering so rings scale/translate with the map
+ * - Colors reflect relationship (self/ally/enemy) and match the theme
+ * - Subtle transparency and glow to fit the game's aesthetic
+ */
+export class RangeOverlayLayer implements Layer {
+  private theme: Theme;
+  private lastMouse: { x: number; y: number } | null = null;
+  private hovered: UnitView | null = null;
+
+  // Rendering constants (screen pixels)
+  private static readonly RING_BASE_WIDTH = 2.5; // stroke width at/under threshold
+  private static readonly RING_OUTLINE_EXTRA = 1.5; // additional px for outer outline
+  private static readonly GROW_ZOOM_THRESHOLD = 2; // match Structure/Road layers' behavior
+
+  constructor(
+    private game: GameView,
+    private eventBus: EventBus,
+    private transform: TransformHandler,
+  ) {
+    this.theme = game.config().theme();
+  }
+
+  shouldTransform(): boolean {
+    return true; // render in world space
+  }
+
+  init() {
+    this.eventBus.on(MouseOverEvent, (e) => {
+      this.lastMouse = { x: e.x, y: e.y };
+      this.updateHoveredUnit();
+    });
+  }
+
+  tick() {
+    // No periodic work needed; we render based on current hover
+  }
+
+  redraw() {
+    // No offscreen buffers to rebuild
+  }
+
+  renderLayer(ctx: CanvasRenderingContext2D) {
+    if (!this.hovered) return;
+
+    const u = this.hovered;
+    const radiusTiles = this.operationRadius(u);
+    if (radiusTiles <= 0) return;
+
+    // Center in world coords (game space), with origin centered like other layers
+    const tile = u.tile();
+    const wx = this.game.x(tile) - this.game.width() / 2 + 0.5;
+    const wy = this.game.y(tile) - this.game.height() / 2 + 0.5;
+
+    // Skip if center is far off-screen
+    const centerCell = new Cell(this.game.x(tile), this.game.y(tile));
+    if (!this.transform.isOnScreen(centerCell)) return;
+
+    // Convert desired on-screen widths to world units by compensating for current transform scale
+    const s = this.transform.scale || 1;
+    const t = RangeOverlayLayer.GROW_ZOOM_THRESHOLD;
+    const screenScale = s <= t ? Math.min(1, s) : s / t;
+    const innerWorldWidth =
+      (RangeOverlayLayer.RING_BASE_WIDTH * screenScale) / s;
+    const outlineWorldWidth =
+      ((RangeOverlayLayer.RING_BASE_WIDTH +
+        RangeOverlayLayer.RING_OUTLINE_EXTRA) *
+        screenScale) /
+      s;
+
+    const relationColor = this.relationshipColor(u);
+    const glow = relationColor.alpha(0.6).toRgbString();
+    const fill = relationColor.alpha(0.14).toRgbString();
+    const stroke = relationColor.alpha(0.85).toRgbString();
+    const outline = relationColor.darken(0.4).alpha(0.8).toRgbString();
+
+    // Filled translucent disk + soft glow
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(wx, wy, radiusTiles, 0, Math.PI * 2);
+    ctx.fillStyle = fill;
+    ctx.shadowColor = glow;
+    ctx.shadowBlur = 8 * screenScale;
+    ctx.fill();
+    ctx.shadowBlur = 0;
+
+    // Outer darker outline
+    ctx.strokeStyle = outline;
+    ctx.lineWidth = outlineWorldWidth;
+    ctx.setLineDash([]);
+    ctx.stroke();
+
+    // Inner bright stroke for definition
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = innerWorldWidth;
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  private updateHoveredUnit() {
+    if (!this.lastMouse) {
+      this.hovered = null;
+      return;
+    }
+    const cell = this.transform.screenToWorldCoordinates(
+      this.lastMouse.x,
+      this.lastMouse.y,
+    );
+    if (!this.game.isValidCoord(cell.x, cell.y)) {
+      this.hovered = null;
+      return;
+    }
+    this.hovered = this.findDefenseOrSAMAtCell(cell);
+  }
+
+  private findDefenseOrSAMAtCell(
+    cell: { x: number; y: number },
+    search: number = 10,
+  ): UnitView | null {
+    const ref = this.game.ref(cell.x, cell.y);
+    const types = [UnitType.DefensePost, UnitType.SAMLauncher];
+    const nearby = this.game.nearbyUnits(ref, search, types);
+    for (const { unit } of nearby) {
+      if (unit.isActive() && types.includes(unit.type())) {
+        return unit;
+      }
+    }
+    return null;
+  }
+
+  private operationRadius(u: UnitView): number {
+    if (u.type() === UnitType.DefensePost) {
+      return this.game.config().defensePostTargettingRange();
+    }
+    if (u.type() === UnitType.SAMLauncher) {
+      const base = this.game.config().defaultSamRange();
+      const bonus = this.game.config().samRangeUpgradePercent();
+      const lvl = u.level();
+      if (lvl <= 1) return base;
+      const factor = Math.pow(1 + bonus, lvl - 1);
+      return Math.round(base * factor);
+    }
+    return 0;
+  }
+
+  private relationshipColor(u: UnitView): Colord {
+    const me = this.game.myPlayer();
+    const owner = u.owner();
+    if (me && owner === me) return this.theme.selfColor();
+    if (me && me.isFriendly(owner)) return this.theme.allyColor();
+    return this.theme.enemyColor();
+  }
+}

--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -1,5 +1,4 @@
-import { Colord } from "colord";
-import { Theme } from "../../../core/configuration/Config";
+// No theme color usage here; ring uses a fixed fallback color
 import { EventBus } from "../../../core/EventBus";
 import { Cell, UnitType } from "../../../core/game/Game";
 import { GameView, UnitView } from "../../../core/game/GameView";
@@ -15,22 +14,17 @@ import { Layer } from "./Layer";
  * - Subtle transparency and glow to fit the game's aesthetic
  */
 export class RangeOverlayLayer implements Layer {
-  private theme: Theme;
   private lastMouse: { x: number; y: number } | null = null;
   private hovered: UnitView | null = null;
 
   // Rendering constants (screen pixels)
-  private static readonly RING_BASE_WIDTH = 2.5; // stroke width at/under threshold
-  private static readonly RING_OUTLINE_EXTRA = 1.5; // additional px for outer outline
   private static readonly GROW_ZOOM_THRESHOLD = 2; // match Structure/Road layers' behavior
 
   constructor(
     private game: GameView,
     private eventBus: EventBus,
     private transform: TransformHandler,
-  ) {
-    this.theme = game.config().theme();
-  }
+  ) {}
 
   shouldTransform(): boolean {
     return true; // render in world space
@@ -71,40 +65,19 @@ export class RangeOverlayLayer implements Layer {
     const s = this.transform.scale || 1;
     const t = RangeOverlayLayer.GROW_ZOOM_THRESHOLD;
     const screenScale = s <= t ? Math.min(1, s) : s / t;
-    const innerWorldWidth =
-      (RangeOverlayLayer.RING_BASE_WIDTH * screenScale) / s;
-    const outlineWorldWidth =
-      ((RangeOverlayLayer.RING_BASE_WIDTH +
-        RangeOverlayLayer.RING_OUTLINE_EXTRA) *
-        screenScale) /
-      s;
+    // Thin 1px stroke in screen space, no fill/glow
+    const worldLineWidth = (1 * screenScale) / s;
 
-    // Use the owner's LIGHT border color as the base hue
-    const baseColor = this.ownerLightBorderColor(u);
-    const glow = baseColor.alpha(0.6).toRgbString();
-    const fill = baseColor.alpha(0.14).toRgbString();
-    const stroke = baseColor.alpha(0.85).toRgbString();
-    const outline = baseColor.darken(0.4).alpha(0.8).toRgbString();
+    // Always use the fallback color, no theme border color
+    const strokeStyle = "rgba(230, 230, 230, 0.9)";
 
-    // Filled translucent disk + soft glow
     ctx.save();
     ctx.beginPath();
     ctx.arc(wx, wy, radiusTiles, 0, Math.PI * 2);
-    ctx.fillStyle = fill;
-    ctx.shadowColor = glow;
-    ctx.shadowBlur = 8 * screenScale;
-    ctx.fill();
-    ctx.shadowBlur = 0;
-
-    // Outer darker outline
-    ctx.strokeStyle = outline;
-    ctx.lineWidth = outlineWorldWidth;
+    ctx.lineWidth = worldLineWidth;
+    // Solid stroke (not dashed)
     ctx.setLineDash([]);
-    ctx.stroke();
-
-    // Inner bright stroke for definition
-    ctx.strokeStyle = stroke;
-    ctx.lineWidth = innerWorldWidth;
+    ctx.strokeStyle = strokeStyle;
     ctx.stroke();
     ctx.restore();
   }
@@ -156,8 +129,5 @@ export class RangeOverlayLayer implements Layer {
     return 0;
   }
 
-  private ownerLightBorderColor(u: UnitView): Colord {
-    const owner = u.owner();
-    return this.theme.defendedBorderColors(owner).light;
-  }
+  // Intentionally empty: no helpers needed after style simplification
 }

--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -79,11 +79,12 @@ export class RangeOverlayLayer implements Layer {
         screenScale) /
       s;
 
-    const relationColor = this.relationshipColor(u);
-    const glow = relationColor.alpha(0.6).toRgbString();
-    const fill = relationColor.alpha(0.14).toRgbString();
-    const stroke = relationColor.alpha(0.85).toRgbString();
-    const outline = relationColor.darken(0.4).alpha(0.8).toRgbString();
+    // Use the owner's LIGHT border color as the base hue
+    const baseColor = this.ownerLightBorderColor(u);
+    const glow = baseColor.alpha(0.6).toRgbString();
+    const fill = baseColor.alpha(0.14).toRgbString();
+    const stroke = baseColor.alpha(0.85).toRgbString();
+    const outline = baseColor.darken(0.4).alpha(0.8).toRgbString();
 
     // Filled translucent disk + soft glow
     ctx.save();
@@ -154,11 +155,8 @@ export class RangeOverlayLayer implements Layer {
     return 0;
   }
 
-  private relationshipColor(u: UnitView): Colord {
-    const me = this.game.myPlayer();
+  private ownerLightBorderColor(u: UnitView): Colord {
     const owner = u.owner();
-    if (me && owner === me) return this.theme.selfColor();
-    if (me && me.isFriendly(owner)) return this.theme.allyColor();
-    return this.theme.enemyColor();
+    return this.theme.defendedBorderColors(owner).light;
   }
 }

--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -48,9 +48,14 @@ export class RangeOverlayLayer implements Layer {
   }
 
   renderLayer(ctx: CanvasRenderingContext2D) {
-    // If in build (ghost) mode for SAM/Defense Post, show ring at cursor
+    // If in build (ghost) mode for selected unit types, show ring at cursor
     const pending = this.uiState.pendingBuildUnitType;
-    if (pending === UnitType.SAMLauncher || pending === UnitType.DefensePost) {
+    if (
+      pending === UnitType.SAMLauncher ||
+      pending === UnitType.DefensePost ||
+      pending === UnitType.AtomBomb ||
+      pending === UnitType.HydrogenBomb
+    ) {
       if (!this.lastMouse) return;
       const cell = this.transform.screenToWorldCoordinates(
         this.lastMouse.x,
@@ -133,7 +138,12 @@ export class RangeOverlayLayer implements Layer {
     search: number = 10,
   ): UnitView | null {
     const ref = this.game.ref(cell.x, cell.y);
-    const types = [UnitType.DefensePost, UnitType.SAMLauncher];
+    const types = [
+      UnitType.DefensePost,
+      UnitType.SAMLauncher,
+      UnitType.AtomBomb,
+      UnitType.HydrogenBomb,
+    ];
     const nearby = this.game.nearbyUnits(ref, search, types);
     for (const { unit } of nearby) {
       if (unit.isActive() && types.includes(unit.type())) {
@@ -156,6 +166,9 @@ export class RangeOverlayLayer implements Layer {
       const factor = Math.pow(1 + bonus, lvl - 1);
       return Math.round(base * factor);
     }
+    if (u.type() === UnitType.AtomBomb || u.type() === UnitType.HydrogenBomb) {
+      return this.game.config().nukeMagnitudes(u.type()).outer;
+    }
     return 0;
   }
 
@@ -164,6 +177,8 @@ export class RangeOverlayLayer implements Layer {
       return this.game.config().defensePostRange();
     if (type === UnitType.SAMLauncher)
       return this.game.config().defaultSamRange();
+    if (type === UnitType.AtomBomb || type === UnitType.HydrogenBomb)
+      return this.game.config().nukeMagnitudes(type).outer;
     return 0;
   }
 

--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -4,6 +4,7 @@ import { Cell, UnitType } from "../../../core/game/Game";
 import { GameView, UnitView } from "../../../core/game/GameView";
 import { MouseOverEvent } from "../../InputHandler";
 import { TransformHandler } from "../TransformHandler";
+import { UIState } from "../UIState";
 import { Layer } from "./Layer";
 
 /**
@@ -24,6 +25,7 @@ export class RangeOverlayLayer implements Layer {
     private game: GameView,
     private eventBus: EventBus,
     private transform: TransformHandler,
+    private uiState: UIState,
   ) {}
 
   shouldTransform(): boolean {
@@ -46,6 +48,25 @@ export class RangeOverlayLayer implements Layer {
   }
 
   renderLayer(ctx: CanvasRenderingContext2D) {
+    // If in build (ghost) mode for SAM/Defense Post, show ring at cursor
+    const pending = this.uiState.pendingBuildUnitType;
+    if (pending === UnitType.SAMLauncher || pending === UnitType.DefensePost) {
+      if (!this.lastMouse) return;
+      const cell = this.transform.screenToWorldCoordinates(
+        this.lastMouse.x,
+        this.lastMouse.y,
+      );
+      if (!this.game.isValidCoord(cell.x, cell.y)) return;
+      const radiusTiles = this.buildModeRadius(pending);
+      if (radiusTiles <= 0) return;
+      // world-space center (map origin centered)
+      const wx = cell.x - this.game.width() / 2 + 0.5;
+      const wy = cell.y - this.game.height() / 2 + 0.5;
+      this.strokeRing(ctx, wx, wy, radiusTiles);
+      return;
+    }
+
+    // Otherwise, show when hovering an existing structure
     if (!this.hovered) return;
 
     const u = this.hovered;
@@ -65,17 +86,26 @@ export class RangeOverlayLayer implements Layer {
     const s = this.transform.scale || 1;
     const t = RangeOverlayLayer.GROW_ZOOM_THRESHOLD;
     const screenScale = s <= t ? Math.min(1, s) : s / t;
+    // Draw the ring at computed world coordinates
+    this.strokeRing(ctx, wx, wy, radiusTiles);
+  }
+
+  private strokeRing(
+    ctx: CanvasRenderingContext2D,
+    wx: number,
+    wy: number,
+    radiusTiles: number,
+  ) {
+    const s = this.transform.scale || 1;
+    const t = RangeOverlayLayer.GROW_ZOOM_THRESHOLD;
+    const screenScale = s <= t ? Math.min(1, s) : s / t;
     // Thin 1px stroke in screen space, no fill/glow
     const worldLineWidth = (1 * screenScale) / s;
-
-    // Always use the fallback color, no theme border color
     const strokeStyle = "rgba(230, 230, 230, 0.9)";
-
     ctx.save();
     ctx.beginPath();
     ctx.arc(wx, wy, radiusTiles, 0, Math.PI * 2);
     ctx.lineWidth = worldLineWidth;
-    // Solid stroke (not dashed)
     ctx.setLineDash([]);
     ctx.strokeStyle = strokeStyle;
     ctx.stroke();
@@ -126,6 +156,14 @@ export class RangeOverlayLayer implements Layer {
       const factor = Math.pow(1 + bonus, lvl - 1);
       return Math.round(base * factor);
     }
+    return 0;
+  }
+
+  private buildModeRadius(type: UnitType): number {
+    if (type === UnitType.DefensePost)
+      return this.game.config().defensePostRange();
+    if (type === UnitType.SAMLauncher)
+      return this.game.config().defaultSamRange();
     return 0;
   }
 

--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -312,6 +312,8 @@ export class StructureLayer implements Layer {
 
   // Compact gold formatter using k/m lowercase suffixes
   private formatGoldCompact(amount: bigint): string {
+    // Special-case zero to preserve 'k' alignment in UI (show 0k)
+    if (amount === 0n) return "0k";
     // Reuse renderNumber for thresholds, then lowercase the suffix
     const s = renderNumber(amount).replace("K", "k").replace("M", "m");
     return s;


### PR DESCRIPTION
This pull request introduces a new visual overlay feature for Defense Posts and SAM Launchers, ensuring their operational radii are clearly shown to the player both when hovering over existing structures and when planning new placements. Additionally, it refines user interaction by automatically disabling upgrade mode when initiating build actions or selecting build items, and improves UI formatting for gold amounts.

**New Feature: Defense/SAM Range Overlay**
* Added `RangeOverlayLayer`, which draws a world-space ring overlay to visualize the operation radius for Defense Posts and SAM Launchers during both build mode and mouse hover. This overlay is integrated into the renderer and responds to game state and user input. (`src/client/graphics/layers/RangeOverlayLayer.ts`, `src/client/graphics/GameRenderer.ts`) [[1]](diffhunk://#diff-f006c834876e3fd97d46645e204f1b8734b1bb4e530e5b4ad5c4736b40580282R1-R171) [[2]](diffhunk://#diff-4105085d0e06ca476384bdda9218cce284812638ffbc4511090d3243996603a5R26) [[3]](diffhunk://#diff-4105085d0e06ca476384bdda9218cce284812638ffbc4511090d3243996603a5R239-R240)

**User Interaction Improvements**
* Automatically disables upgrade mode and unhighlights the upgrade button when a build action is initiated via hotkey or when placing a structure, ensuring consistent UI state. (`src/client/InputHandler.ts`) [[1]](diffhunk://#diff-5c405089ec4c6304bdd60a1f42ff81fc3ec332150f6e0f0c7083886636330b8aR377-R381) [[2]](diffhunk://#diff-5c405089ec4c6304bdd60a1f42ff81fc3ec332150f6e0f0c7083886636330b8aR468-R472)
* Selecting a build item in the build menu also exits upgrade mode and unhighlights the upgrade button for improved user feedback. (`src/client/graphics/layers/BuildMenu.ts`)

**UI Formatting Enhancement**
* Gold amounts in the structure layer are now formatted to always show a "0k" for zero values, improving alignment and clarity in the UI. (`src/client/graphics/layers/StructureLayer.ts`)
