### PR TITLE
feat: Add tooltips to Multi-Build and Upgrade buttons

### DIFF
--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -1241,7 +1241,7 @@ export class ControlPanel2 extends LitElement implements Layer {
                     class="upgrade-structures-button ${this._multibuildEnabled
                       ? "selected"
                       : ""}"
-                    title="Multi-Build Structures"
+                    title="Place multiple structures without re-selecting"
                     @click=${this._handleMultibuildToggle}
                   >
                     <img
@@ -1255,7 +1255,7 @@ export class ControlPanel2 extends LitElement implements Layer {
                     class="upgrade-structures-button ${this.uiState.upgradeMode
                       ? "selected"
                       : ""}"
-                    title="Upgrade Structures"
+                    title="Click structures to upgrade them"
                     @click=${() => {
                       const enabled = !this.uiState.upgradeMode;
                       this.uiState.upgradeMode = enabled;
@@ -1759,6 +1759,7 @@ style.textContent = `
     font-size: 13px;
     font-weight: bold;
     white-space: nowrap;
+    position: relative;
   }
   .upgrade-structures-button .upgrade-icon {
     width: 18px;


### PR DESCRIPTION
## Description:
- Multi-Build tooltip: 'Place multiple structures without re-selecting'
<img width="701" height="286" alt="image" src="https://github.com/user-attachments/assets/118e793f-5f59-4070-80c3-fade5b907155" />

- Upgrade tooltip: 'Click structures to upgrade them'
<img width="698" height="297" alt="image" src="https://github.com/user-attachments/assets/a92358c1-e68a-43f8-8e8e-2667f00e92ad" />

- Uses native title attribute for consistent styling with BuildMenu


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
