### PR TITLE
Add Health Bar to All Units

### DIFF
--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -1254,27 +1254,9 @@ export class StructureLayer implements Layer {
   private updateHealthBar(render: StructureRenderInfo) {
     const unit = render.unit;
 
-    // Calculate max health based on unit type and level
-    let maxHealth = this.game.unitInfo(unit.type()).maxHealth;
+    // Get max health from centralized calculation
+    const maxHealth = unit.effectiveMaxHealth();
     if (!maxHealth) return; // No health for this unit type
-
-    if (
-      unit.type() === UnitType.City ||
-      unit.type() === UnitType.Port ||
-      unit.type() === UnitType.Hospital ||
-      unit.type() === UnitType.Academy ||
-      unit.type() === UnitType.ResearchLab ||
-      unit.type() === UnitType.Factory
-    ) {
-      const lvl = unit.level();
-      maxHealth = maxHealth + (lvl - 1) * 1000;
-    } else if (
-      unit.type() === UnitType.MissileSilo ||
-      unit.type() === UnitType.SAMLauncher
-    ) {
-      const lvl = unit.level();
-      maxHealth = maxHealth + (lvl - 1) * 250;
-    }
 
     // Only show health bar if damaged and active
     if (!unit.isActive() || unit.health() >= maxHealth || unit.health() <= 0) {
@@ -1395,15 +1377,18 @@ export class StructureLayer implements Layer {
     graphics.x = render.pixiSprite.x;
     graphics.y = render.pixiSprite.y + yOffset;
 
-    // Calculate progress
+    // Calculate progress using cooldownEndsAt (authoritative field)
     const totalCooldown =
       unit.type() === UnitType.MissileSilo
         ? (unit.cooldownDuration() ?? this.game.config().SiloCooldown())
         : (unit.cooldownDuration() ?? this.game.config().SAMNukeCooldown());
-    const ticksLeft = unit.ticksLeftInCooldown() ?? 0;
+    const endsAt = unit.cooldownEndsAt();
     const currentTick = this.game.ticks();
-    const actualStartTick = currentTick - (totalCooldown - ticksLeft);
-    const progress = (currentTick - actualStartTick) / totalCooldown;
+
+    // Progress from 0 (just started) to 1 (ready)
+    const startTick = endsAt ? endsAt - totalCooldown : currentTick;
+    const elapsed = currentTick - startTick;
+    const progress = Math.min(1, Math.max(0, elapsed / totalCooldown));
 
     // Background (black border)
     graphics.beginFill(0x000000, 1);

--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -27,6 +27,8 @@ import { Layer } from "./Layer";
 class StructureRenderInfo {
   public isOnScreen: boolean = false;
   public isOnCooldown: boolean = false;
+  public healthBarGraphics: PIXI.Graphics | null = null;
+  public loadingBarGraphics: PIXI.Graphics | null = null;
   constructor(
     public unit: UnitView,
     public owner: PlayerID,
@@ -253,6 +255,9 @@ export class StructureLayer implements Layer {
           );
           if (render) {
             this.updateRenderState(render, unitView);
+            // Update health and loading bars
+            this.updateHealthBar(render);
+            this.updateLoadingBar(render);
           }
         } else if (
           this.structures.has(unitView.type()) ||
@@ -267,6 +272,9 @@ export class StructureLayer implements Layer {
           );
           this.renders.push(render);
           this.computeNewLocation(render);
+          // Initialize bars
+          this.updateHealthBar(render);
+          this.updateLoadingBar(render);
           this.shouldRedraw = true;
         }
       }
@@ -277,6 +285,13 @@ export class StructureLayer implements Layer {
           this.deleteStructure(render);
         }
         this.shouldRedraw = true;
+      }
+    }
+
+    // Update all bars every tick (for smooth loading bar progress)
+    for (const render of this.renders) {
+      if (render.loadingBarGraphics) {
+        this.updateLoadingBar(render);
       }
     }
   }
@@ -876,10 +891,22 @@ export class StructureLayer implements Layer {
       render.pixiSprite.x = screenPos.x;
       render.pixiSprite.y = screenPos.y;
       render.pixiSprite.scale.set(this.iconScreenScale());
+      // Update bars when position/scale changes
+      this.updateHealthBar(render);
+      this.updateLoadingBar(render);
     }
     if (render.isOnScreen !== onScreen) {
       render.isOnScreen = onScreen;
       render.pixiSprite.visible = onScreen;
+      // Hide bars when off screen
+      if (!onScreen) {
+        if (render.healthBarGraphics) {
+          render.healthBarGraphics.visible = false;
+        }
+        if (render.loadingBarGraphics) {
+          render.loadingBarGraphics.visible = false;
+        }
+      }
     }
   }
 
@@ -1211,7 +1238,196 @@ export class StructureLayer implements Layer {
 
   private deleteStructure(render: StructureRenderInfo) {
     render.pixiSprite?.destroy();
+    // Clean up health and loading bars
+    if (render.healthBarGraphics) {
+      render.healthBarGraphics.destroy();
+      render.healthBarGraphics = null;
+    }
+    if (render.loadingBarGraphics) {
+      render.loadingBarGraphics.destroy();
+      render.loadingBarGraphics = null;
+    }
     this.renders = this.renders.filter((r) => r.unit !== render.unit);
     this.seenUnits.delete(render.unit);
+  }
+
+  private updateHealthBar(render: StructureRenderInfo) {
+    const unit = render.unit;
+
+    // Calculate max health based on unit type and level
+    let maxHealth = this.game.unitInfo(unit.type()).maxHealth;
+    if (!maxHealth) return; // No health for this unit type
+
+    if (
+      unit.type() === UnitType.City ||
+      unit.type() === UnitType.Port ||
+      unit.type() === UnitType.Hospital ||
+      unit.type() === UnitType.Academy ||
+      unit.type() === UnitType.ResearchLab ||
+      unit.type() === UnitType.Factory
+    ) {
+      const lvl = unit.level();
+      maxHealth = maxHealth + (lvl - 1) * 1000;
+    } else if (
+      unit.type() === UnitType.MissileSilo ||
+      unit.type() === UnitType.SAMLauncher
+    ) {
+      const lvl = unit.level();
+      maxHealth = maxHealth + (lvl - 1) * 250;
+    }
+
+    // Only show health bar if damaged and active
+    if (!unit.isActive() || unit.health() >= maxHealth || unit.health() <= 0) {
+      if (render.healthBarGraphics) {
+        render.healthBarGraphics.destroy();
+        render.healthBarGraphics = null;
+        this.shouldRedraw = true;
+      }
+      return;
+    }
+
+    // Create or update health bar
+    if (!render.healthBarGraphics) {
+      render.healthBarGraphics = new PIXI.Graphics();
+      this.stage.addChild(render.healthBarGraphics);
+    }
+
+    const graphics = render.healthBarGraphics;
+    graphics.clear();
+
+    // Get the structure's icon size and scale
+    const unitType =
+      unit.type() === UnitType.Construction
+        ? unit.constructionType()
+        : unit.type();
+    const shape: BgShape =
+      unitType !== undefined
+        ? (STRUCTURE_BG_SHAPES[unitType as UnitType] ?? "circle")
+        : "circle";
+    const iconDim = ICON_SIZES[shape] ?? ICON_SIZE;
+    const spriteScale = render.pixiSprite.scale.x; // Assumes uniform scaling
+    const scaledIconSize = iconDim * spriteScale;
+
+    // Bar dimensions scale with the icon (doubled size)
+    const barWidth = scaledIconSize * 3; // 160% of icon width (doubled from 80%)
+    const barHeight = scaledIconSize * 0.3; // ~16% of icon height (doubled from 8%), min 4px
+    const gap = scaledIconSize * 1.8; // Gap scales with icon size (50% of icon size)
+    const yOffset = -(scaledIconSize / 2 + barHeight + gap);
+
+    // Position relative to sprite center
+    graphics.x = render.pixiSprite.x;
+    graphics.y = render.pixiSprite.y + yOffset;
+
+    // Background (black border)
+    graphics.beginFill(0x000000, 1);
+    graphics.drawRect(-barWidth / 2 - 1, -1, barWidth + 2, barHeight + 2);
+    graphics.endFill();
+
+    // Health fill (color based on health percentage)
+    const healthPercent = unit.health() / maxHealth;
+    const colors = [0xe81919, 0xf07a19, 0xcae70f, 0x2cef12]; // red, orange, yellow, green
+    const colorIndex = Math.min(
+      colors.length - 1,
+      Math.floor(healthPercent * colors.length),
+    );
+    const fillColor = colors[colorIndex];
+
+    graphics.beginFill(fillColor, 1);
+    graphics.drawRect(
+      -barWidth / 2,
+      0,
+      Math.max(1, healthPercent * barWidth),
+      barHeight,
+    );
+    graphics.endFill();
+
+    graphics.visible = render.isOnScreen;
+    this.shouldRedraw = true;
+  }
+
+  private updateLoadingBar(render: StructureRenderInfo) {
+    const unit = render.unit;
+
+    // Only show loading bar for structures on cooldown
+    if (
+      !unit.isActive() ||
+      !unit.isCooldown() ||
+      (unit.type() !== UnitType.MissileSilo &&
+        unit.type() !== UnitType.SAMLauncher)
+    ) {
+      if (render.loadingBarGraphics) {
+        render.loadingBarGraphics.destroy();
+        render.loadingBarGraphics = null;
+        this.shouldRedraw = true;
+      }
+      return;
+    }
+
+    // Create or update loading bar
+    if (!render.loadingBarGraphics) {
+      render.loadingBarGraphics = new PIXI.Graphics();
+      this.stage.addChild(render.loadingBarGraphics);
+    }
+
+    const graphics = render.loadingBarGraphics;
+    graphics.clear();
+
+    // Get the structure's icon size and scale
+    const unitType =
+      unit.type() === UnitType.Construction
+        ? unit.constructionType()
+        : unit.type();
+    const shape: BgShape =
+      unitType !== undefined
+        ? (STRUCTURE_BG_SHAPES[unitType as UnitType] ?? "circle")
+        : "circle";
+    const iconDim = ICON_SIZES[shape] ?? ICON_SIZE;
+    const spriteScale = render.pixiSprite.scale.x; // Assumes uniform scaling
+    const scaledIconSize = iconDim * spriteScale;
+
+    // Bar dimensions scale with the icon (same as health bar)
+    const barWidth = scaledIconSize * 3; // 300% of icon width
+    const barHeight = scaledIconSize * 0.3; // 30% of icon height, min 4px
+    const gap = scaledIconSize * 1.8;
+    const yOffset = scaledIconSize / 2 + barHeight + gap; // Below the icon with scaled gap
+
+    // Position relative to sprite center
+    graphics.x = render.pixiSprite.x;
+    graphics.y = render.pixiSprite.y + yOffset;
+
+    // Calculate progress
+    const totalCooldown =
+      unit.type() === UnitType.MissileSilo
+        ? (unit.cooldownDuration() ?? this.game.config().SiloCooldown())
+        : (unit.cooldownDuration() ?? this.game.config().SAMNukeCooldown());
+    const ticksLeft = unit.ticksLeftInCooldown() ?? 0;
+    const currentTick = this.game.ticks();
+    const actualStartTick = currentTick - (totalCooldown - ticksLeft);
+    const progress = (currentTick - actualStartTick) / totalCooldown;
+
+    // Background (black border)
+    graphics.beginFill(0x000000, 1);
+    graphics.drawRect(-barWidth / 2 - 1, -1, barWidth + 2, barHeight + 2);
+    graphics.endFill();
+
+    // Progress fill (color based on progress)
+    const colors = [0xe81919, 0xf07a19, 0xcae70f, 0x2cef12]; // red, orange, yellow, green
+    const colorIndex = Math.min(
+      colors.length - 1,
+      Math.floor(progress * colors.length),
+    );
+    const fillColor = colors[colorIndex];
+
+    graphics.beginFill(fillColor, 1);
+    graphics.drawRect(
+      -barWidth / 2,
+      0,
+      Math.max(1, progress * barWidth),
+      barHeight,
+    );
+    graphics.endFill();
+
+    graphics.visible = render.isOnScreen;
+    this.shouldRedraw = true;
   }
 }

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -278,42 +278,9 @@ export class UILayer implements Layer {
    * Draw health bar for a unit
    */
   public drawHealthBar(unit: UnitView) {
-    // Use effective max health for upgradeable structures, otherwise static info
-    let maxHealth = this.game.unitInfo(unit.type()).maxHealth;
-    if (
-      unit.type() === UnitType.City ||
-      unit.type() === UnitType.Port ||
-      unit.type() === UnitType.Hospital ||
-      unit.type() === UnitType.Academy ||
-      unit.type() === UnitType.ResearchLab ||
-      unit.type() === UnitType.Factory
-    ) {
-      // These structures can be upgraded: +1000 max HP per level
-      const lvl = unit.level();
-      if (typeof maxHealth === "number") {
-        maxHealth = maxHealth + (lvl - 1) * 1000;
-      }
-    } else if (
-      unit.type() === UnitType.MissileSilo ||
-      unit.type() === UnitType.SAMLauncher
-    ) {
-      // Silo and SAM: +250 max HP per level (capped at level 3)
-      const lvl = unit.level();
-      if (typeof maxHealth === "number") {
-        maxHealth = maxHealth + (lvl - 1) * 250;
-      }
-    } else if (unit.type() === UnitType.FighterJet) {
-      // Fighter Jet: per-level max health from config
-      const lvl = unit.level ? unit.level() : 1;
-      maxHealth = this.game.config().fighterJetLevelMaxHealth(lvl);
-    } else if (unit.type() === UnitType.Warship) {
-      const lvl = unit.level ? unit.level() : 1;
-      maxHealth = this.game.config().warshipLevelMaxHealth(lvl);
-    } else if (unit.type() === UnitType.Submarine) {
-      const lvl = unit.level ? unit.level() : 1;
-      maxHealth = this.game.config().submarineLevelMaxHealth(lvl);
-    }
-    if (maxHealth === undefined || this.context === null) {
+    // Use centralized effective max health calculation
+    const maxHealth = unit.effectiveMaxHealth();
+    if (maxHealth === 0 || this.context === null) {
       return;
     }
     if (

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -152,46 +152,8 @@ export class UILayer implements Layer {
         this.drawHealthBar(unit);
         break;
       }
-      case UnitType.MissileSilo:
-        // Show health bar if damaged
-        this.drawHealthBar(unit);
-        // Also show loading bar when on cooldown
-        if (
-          unit.isActive() &&
-          unit.isCooldown() &&
-          !this.allProgressBars.has(unit.id())
-        ) {
-          const totalCooldown =
-            unit.cooldownDuration() ?? this.game.config().SiloCooldown();
-          this.drawLoadingBar(unit, totalCooldown);
-        }
-        break;
-      case UnitType.SAMLauncher:
-        // Show health bar if damaged
-        this.drawHealthBar(unit);
-        // Also show loading bar when on cooldown
-        if (
-          unit.isActive() &&
-          unit.isCooldown() &&
-          !this.allProgressBars.has(unit.id())
-        ) {
-          const totalCooldown =
-            unit.cooldownDuration() ?? this.game.config().SAMNukeCooldown();
-          this.drawLoadingBar(unit, totalCooldown);
-        }
-        break;
-      // Other structures with health bars only
-      case UnitType.City:
-      case UnitType.Port:
-      case UnitType.Hospital:
-      case UnitType.Academy:
-      case UnitType.ResearchLab:
-      case UnitType.Factory:
-      case UnitType.Airfield:
-      case UnitType.DefensePost:
-      case UnitType.DoomsdayDevice:
-        this.drawHealthBar(unit);
-        break;
+      // Note: Structure health bars and loading bars (MissileSilo, SAMLauncher, etc.)
+      // are now handled in StructureLayer for proper zoom/pan alignment
       default:
         return;
     }

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -153,6 +153,9 @@ export class UILayer implements Layer {
         break;
       }
       case UnitType.MissileSilo:
+        // Show health bar if damaged
+        this.drawHealthBar(unit);
+        // Also show loading bar when on cooldown
         if (
           unit.isActive() &&
           unit.isCooldown() &&
@@ -164,6 +167,9 @@ export class UILayer implements Layer {
         }
         break;
       case UnitType.SAMLauncher:
+        // Show health bar if damaged
+        this.drawHealthBar(unit);
+        // Also show loading bar when on cooldown
         if (
           unit.isActive() &&
           unit.isCooldown() &&
@@ -173,6 +179,18 @@ export class UILayer implements Layer {
             unit.cooldownDuration() ?? this.game.config().SAMNukeCooldown();
           this.drawLoadingBar(unit, totalCooldown);
         }
+        break;
+      // Other structures with health bars only
+      case UnitType.City:
+      case UnitType.Port:
+      case UnitType.Hospital:
+      case UnitType.Academy:
+      case UnitType.ResearchLab:
+      case UnitType.Factory:
+      case UnitType.Airfield:
+      case UnitType.DefensePost:
+      case UnitType.DoomsdayDevice:
+        this.drawHealthBar(unit);
         break;
       default:
         return;
@@ -298,13 +316,29 @@ export class UILayer implements Layer {
    * Draw health bar for a unit
    */
   public drawHealthBar(unit: UnitView) {
-    // Use effective max health for cities (may be upgraded) otherwise static info
+    // Use effective max health for upgradeable structures, otherwise static info
     let maxHealth = this.game.unitInfo(unit.type()).maxHealth;
-    if (unit.type() === UnitType.City) {
+    if (
+      unit.type() === UnitType.City ||
+      unit.type() === UnitType.Port ||
+      unit.type() === UnitType.Hospital ||
+      unit.type() === UnitType.Academy ||
+      unit.type() === UnitType.ResearchLab ||
+      unit.type() === UnitType.Factory
+    ) {
+      // These structures can be upgraded: +1000 max HP per level
       const lvl = unit.level();
-      // Base maxHealth from unitInfo applies to level 1; each upgrade adds +1000
       if (typeof maxHealth === "number") {
         maxHealth = maxHealth + (lvl - 1) * 1000;
+      }
+    } else if (
+      unit.type() === UnitType.MissileSilo ||
+      unit.type() === UnitType.SAMLauncher
+    ) {
+      // Silo and SAM: +250 max HP per level (capped at level 3)
+      const lvl = unit.level();
+      if (typeof maxHealth === "number") {
+        maxHealth = maxHealth + (lvl - 1) * 250;
       }
     } else if (unit.type() === UnitType.FighterJet) {
       // Fighter Jet: per-level max health from config

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -550,6 +550,7 @@ export interface Unit {
   // Upgrades
   level(): number; // Current upgrade level (>=1)
   upgradeStructure(): void; // Applies structure-specific upgrade effects (currently City only)
+  effectiveMaxHealth(): number; // Base max health + bonuses from upgrades
 }
 
 export interface TerraNullius {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -134,6 +134,7 @@ export interface UnitUpdate {
   targetUnitId?: number; // Only for trade ships
   targetTile?: TileRef; // Only for nukes
   health?: number;
+  maxHealth?: number; // Effective max health (base + bonuses)
   constructionType?: UnitType;
   // Deprecated: ticksLeftInCooldown is replaced by cooldownEndsAt
   ticksLeftInCooldown?: Tick;

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -202,6 +202,11 @@ export class UnitView {
       | undefined;
     return Array.isArray(arr) ? [...arr] : [];
   }
+
+  // Get effective max health from server
+  effectiveMaxHealth(): number {
+    return this.data.maxHealth ?? 0;
+  }
 }
 
 export class PlayerView {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -462,20 +462,11 @@ export class PlayerImpl implements Player {
       .filter((u) => u.type() === type && u.isActive())
       .reduce((sum, u) => {
         // Use effective max for health ratio so city upgrades don't inflate ratios.
-        const baseMax = u.info().maxHealth ?? 1;
-        const level = (u as any).level?.() ?? 1;
-        const effectiveMax =
-          u.type() === UnitType.City ||
-          u.type() === UnitType.Port ||
-          u.type() === UnitType.Hospital ||
-          u.type() === UnitType.Academy ||
-          u.type() === UnitType.ResearchLab ||
-          u.type() === UnitType.Factory
-            ? baseMax + 1000 * Math.max(0, level - 1)
-            : baseMax;
+        const effectiveMax = u.effectiveMaxHealth();
         const healthRatio = u.hasHealth()
           ? Math.min(1, Number(u.health()) / Math.max(1, effectiveMax))
           : 1;
+        const level = (u as any).level?.() ?? 1;
         return sum + healthRatio * level;
       }, 0);
     this._effectiveUnitsCache.set(type, calculatedValue);

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -163,6 +163,7 @@ export class UnitImpl implements Unit {
       targetable: this._targetable,
       lastPos: this._lastTile,
       health: this.hasHealth() ? Number(this._health) : undefined,
+      maxHealth: this.hasHealth() ? this.effectiveMaxHealth() : undefined,
       level: this._level > 1 ? this._level : undefined,
       constructionType: this._constructionType,
       targetUnitId: this._targetUnit?.id() ?? undefined,
@@ -250,7 +251,7 @@ export class UnitImpl implements Unit {
     return this.mg.unitInfo(this._type).maxHealth ?? 1;
   }
 
-  private effectiveMaxHealth(): number {
+  effectiveMaxHealth(): number {
     return this.baseMaxHealth() + this._bonusMaxHealth;
   }
 


### PR DESCRIPTION
This pull request enhances the health bar rendering logic for various unit types in the `UILayer` class, making the UI more informative and consistent for upgradeable structures and defensive units. The changes ensure that health bars are displayed for damaged structures and that max health calculations account for unit upgrades.

**UI rendering improvements:**

* Health bars are now shown for damaged `MissileSilo` and `SAMLauncher` units, in addition to their loading bars when on cooldown. [[1]](diffhunk://#diff-33e855dbbe80d10a1aee0d6f07c30d1eb85a87d7a9c031373ce64a403071821eR156-R158) [[2]](diffhunk://#diff-33e855dbbe80d10a1aee0d6f07c30d1eb85a87d7a9c031373ce64a403071821eR170-R172)
* Health bars are also displayed for other structures such as `City`, `Port`, `Hospital`, `Academy`, `ResearchLab`, `Factory`, `Airfield`, `DefensePost`, and `DoomsdayDevice` when damaged.

**Health bar logic updates:**

* The `drawHealthBar` method now calculates max health for upgradeable structures (`City`, `Port`, `Hospital`, `Academy`, `ResearchLab`, `Factory`) by adding +1000 HP per upgrade level.
* For `MissileSilo` and `SAMLauncher`, the max health increases by +250 HP per level (capped at level 3).