### PR TITLE
fix(ControlPanel): remove hospital returns from population display to prevent overflow

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -362,10 +362,7 @@ export class ControlPanel extends LitElement implements Layer {
                             ? "var(--ui-slider-troop)"
                             : "var(--ui-alert)"}"
                         >
-                          (+${renderTroops(this.popRate)}${this
-                            ._hospitalReturns > 0
-                            ? `/ +${renderTroops(this._hospitalReturns)}`
-                            : ""})
+                          (+${renderTroops(this.popRate)})
                         </span>
                       </span>
                     </div>

--- a/tests/client/graphics/UILayer.test.ts
+++ b/tests/client/graphics/UILayer.test.ts
@@ -71,6 +71,7 @@ describe("UILayer", () => {
       tile: () => ({}),
       owner: () => ({}),
       isActive: () => true,
+      effectiveMaxHealth: () => 10,
     };
 
     ui.drawHealthBar(unit);
@@ -101,6 +102,7 @@ describe("UILayer", () => {
       tile: () => ({}),
       owner: () => ({}),
       isActive: () => true,
+      effectiveMaxHealth: () => 10,
     };
 
     ui.drawHealthBar(unit);
@@ -190,6 +192,7 @@ describe("UILayer", () => {
       isAttacking: () => false,
       isDetectedByNavalUnit: () => false,
       isCooldown: () => false,
+      effectiveMaxHealth: () => 10,
     };
 
     // Routed through onUnitEvent to apply visibility rules
@@ -215,6 +218,7 @@ describe("UILayer", () => {
       isAttacking: () => false,
       isDetectedByNavalUnit: () => false,
       isCooldown: () => false,
+      effectiveMaxHealth: () => 10,
     };
 
     (ui as any).onUnitEvent(sub);
@@ -239,6 +243,7 @@ describe("UILayer", () => {
       isAttacking: () => false,
       isDetectedByNavalUnit: () => true,
       isCooldown: () => false,
+      effectiveMaxHealth: () => 10,
     };
 
     (ui as any).onUnitEvent(sub);


### PR DESCRIPTION
## Description:

remove hospital returns from population display to prevent overflow. I doubt anyone knew it was htere in the first place. 

Old
<img width="336" height="299" alt="image" src="https://github.com/user-attachments/assets/a43ce2a4-60cb-476c-9fad-34dacfc70c94" />

New
<img width="335" height="296" alt="image" src="https://github.com/user-attachments/assets/5d01cf9c-fc11-4776-862b-bc58dc968837" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
