### PR TITLE
fix(graphics): show SAM placement range based on selected build level

### DIFF
--- a/src/client/graphics/layers/RangeOverlayLayer.ts
+++ b/src/client/graphics/layers/RangeOverlayLayer.ts
@@ -415,8 +415,28 @@ export class RangeOverlayLayer implements Layer {
   private buildModeRadius(type: UnitType): number {
     if (type === UnitType.DefensePost)
       return this.game.config().defensePostRange();
-    if (type === UnitType.SAMLauncher)
-      return this.game.config().defaultSamRange();
+    if (type === UnitType.SAMLauncher) {
+      // Get the selected build level from localStorage (same as BuildMenu)
+      let desiredLevel = 1;
+      try {
+        const raw = localStorage.getItem("buildSettings.levels");
+        if (raw) {
+          const obj = JSON.parse(raw);
+          const val = obj?.[String(type)];
+          if (typeof val === "number" && val >= 1) {
+            desiredLevel = Math.min(3, val); // SAM max level is 3
+          }
+        }
+      } catch (_) {
+        // Fall back to level 1
+      }
+
+      const base = this.game.config().defaultSamRange();
+      if (desiredLevel <= 1) return base;
+      const bonus = this.game.config().samRangeUpgradePercent();
+      const factor = Math.pow(1 + bonus, desiredLevel - 1);
+      return Math.round(base * factor);
+    }
     if (type === UnitType.AtomBomb || type === UnitType.HydrogenBomb)
       return this.game.config().nukeMagnitudes(type).outer;
     return 0;


### PR DESCRIPTION
## Description:

fix(graphics): show SAM placement range based on selected build level
<img width="486" height="734" alt="image" src="https://github.com/user-attachments/assets/84ec57e1-9d90-42fe-8ef3-73703a757042" />
<img width="587" height="834" alt="image" src="https://github.com/user-attachments/assets/51482f1b-ab8d-4c5d-b763-9e0df1ee6fe1" />
<img width="627" height="838" alt="image" src="https://github.com/user-attachments/assets/87b40552-90e9-4a71-a0e2-0522459f3958" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
