### PR TITLE
feat: Add Gold Multiplier setting for lobbies and singleplayer

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -176,6 +176,9 @@
     "default": "0 (default)",
     "millions": "{amount}M"
   },
+  "gold_multiplier": {
+    "label": "Gold Multiplier"
+  },
   "private_lobby": {
     "title": "Join Private Lobby",
     "enter_id": "Enter Lobby ID",

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -21,6 +21,7 @@ import {
   ClientInfo,
   GameConfig,
   GameInfo,
+  GoldMultiplierValues,
   PeaceTimerDuration,
   StartingGoldValues,
   TeamCountConfig,
@@ -37,6 +38,11 @@ type StartingGoldOption = (typeof StartingGoldValues)[number];
 const startingGoldList = [...StartingGoldValues] as number[];
 const isStartingGoldOption = (value: number): value is StartingGoldOption =>
   startingGoldList.includes(value);
+
+type GoldMultiplierOption = (typeof GoldMultiplierValues)[number];
+const goldMultiplierList = [...GoldMultiplierValues] as number[];
+const isGoldMultiplierOption = (value: number): value is GoldMultiplierOption =>
+  goldMultiplierList.includes(value);
 
 @customElement("host-lobby-modal")
 export class HostLobbyModal extends LitElement {
@@ -65,6 +71,7 @@ export class HostLobbyModal extends LitElement {
   @state() private selectedPeaceTimerDuration: PeaceTimerDuration =
     PeaceTimerDuration.None;
   @state() private startingGold: StartingGoldOption = StartingGoldValues[0];
+  @state() private goldMultiplier: GoldMultiplierOption = 1;
   @state() private playerTeamAssignments: Record<string, number | null> = {};
   @state() private updatingTeamForClients: Set<string> = new Set();
   @state() private showUnitSettings = false; // Closed by default for Host
@@ -815,8 +822,25 @@ export class HostLobbyModal extends LitElement {
                   />
                 </div>
 
-                <!-- Dropdowns -->
-                <div class="grid grid-cols-2 gap-4 mb-3">
+                <!-- Dropdowns (3 columns) -->
+                <div class="grid grid-cols-3 gap-4 mb-3">
+                  <div class="flex flex-col">
+                    <div class="text-sm text-gray-300 mb-1 font-bold">
+                      ${translateText("gold_multiplier.label")}
+                    </div>
+                    <select
+                      class="sp-select"
+                      @change=${this.handleGoldMultiplierChange}
+                      .value=${String(this.goldMultiplier)}
+                    >
+                      ${GoldMultiplierValues.map(
+                        (v) =>
+                          html`<option value=${v}>
+                            ${v}x${v === 1 ? " (Default)" : ""}
+                          </option>`,
+                      )}
+                    </select>
+                  </div>
                   <div class="flex flex-col">
                     <div class="text-sm text-gray-300 mb-1 font-bold">
                       ${translateText("starting_gold.label")}
@@ -1034,6 +1058,9 @@ export class HostLobbyModal extends LitElement {
         } else {
           this.startingGold = 0;
         }
+        if (lobby.gameConfig?.goldMultiplier !== undefined) {
+          this.goldMultiplier = lobby.gameConfig.goldMultiplier;
+        }
       })
       .then(() => {
         this.dispatchEvent(
@@ -1120,6 +1147,15 @@ export class HostLobbyModal extends LitElement {
       return;
     }
     this.startingGold = value;
+    this.putGameConfig();
+  }
+
+  private handleGoldMultiplierChange(e: Event) {
+    const value = parseFloat((e.target as HTMLSelectElement).value);
+    if (isNaN(value) || !isGoldMultiplierOption(value)) {
+      return;
+    }
+    this.goldMultiplier = value;
     this.putGameConfig();
   }
 
@@ -1440,6 +1476,7 @@ export class HostLobbyModal extends LitElement {
           playerTeamAssignments: assignmentsPayload,
           peaceTimerDurationMinutes: this.selectedPeaceTimerDuration,
           startingGold: this.startingGold,
+          goldMultiplier: this.goldMultiplier,
         } satisfies Partial<GameConfig>),
       },
     );
@@ -1547,6 +1584,9 @@ export class HostLobbyModal extends LitElement {
         }
         if (data.gameConfig?.startingGold !== undefined) {
           this.startingGold = data.gameConfig.startingGold;
+        }
+        if (data.gameConfig?.goldMultiplier !== undefined) {
+          this.goldMultiplier = data.gameConfig.goldMultiplier;
         }
         if (data.gameConfig?.researchAllTechs !== undefined) {
           this.researchAllTechs = Boolean(data.gameConfig.researchAllTechs);

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -14,6 +14,7 @@ import {
   mapCategories,
 } from "../core/game/Game";
 import {
+  GoldMultiplierValues,
   PeaceTimerDuration,
   StartingGoldValues,
   TeamCountConfig,
@@ -33,6 +34,11 @@ type StartingGoldOption = (typeof StartingGoldValues)[number];
 const startingGoldList = [...StartingGoldValues] as number[];
 const isStartingGoldOption = (value: number): value is StartingGoldOption =>
   startingGoldList.includes(value);
+
+type GoldMultiplierOption = (typeof GoldMultiplierValues)[number];
+const goldMultiplierList = [...GoldMultiplierValues] as number[];
+const isGoldMultiplierOption = (value: number): value is GoldMultiplierOption =>
+  goldMultiplierList.includes(value);
 
 @customElement("single-player-modal")
 export class SinglePlayerModal extends LitElement {
@@ -55,6 +61,7 @@ export class SinglePlayerModal extends LitElement {
   @state() private selectedPeaceTimerDuration: PeaceTimerDuration =
     PeaceTimerDuration.None;
   @state() private startingGold: StartingGoldOption = StartingGoldValues[0];
+  @state() private goldMultiplier: GoldMultiplierOption = 1;
 
   @state() private disabledUnits: UnitType[] = [];
   @state() private showUnitSettings = true; // Open by default
@@ -552,7 +559,24 @@ export class SinglePlayerModal extends LitElement {
                 </div>
 
                 <!-- Dropdowns with Labels -->
-                <div class="grid grid-cols-2 gap-4 mb-3">
+                <div class="grid grid-cols-3 gap-4 mb-3">
+                  <div class="flex flex-col">
+                    <div class="text-sm text-gray-300 mb-1 font-bold">
+                      ${translateText("gold_multiplier.label")}
+                    </div>
+                    <select
+                      class="sp-select"
+                      @change=${this.handleGoldMultiplierChange}
+                      .value=${String(this.goldMultiplier)}
+                    >
+                      ${GoldMultiplierValues.map(
+                        (v) =>
+                          html`<option value=${v}>
+                            ${v}x${v === 1 ? " (Default)" : ""}
+                          </option>`,
+                      )}
+                    </select>
+                  </div>
                   <div class="flex flex-col">
                     <div class="text-sm text-gray-300 mb-1 font-bold">
                       ${translateText("starting_gold.label")}
@@ -785,6 +809,14 @@ export class SinglePlayerModal extends LitElement {
     this.startingGold = value;
   }
 
+  private handleGoldMultiplierChange(e: Event) {
+    const value = parseFloat((e.target as HTMLSelectElement).value);
+    if (isNaN(value) || !isGoldMultiplierOption(value)) {
+      return;
+    }
+    this.goldMultiplier = value;
+  }
+
   private handlePeaceTimerChange(e: Event) {
     this.selectedPeaceTimerDuration = parseInt(
       (e.target as HTMLSelectElement).value,
@@ -874,6 +906,7 @@ export class SinglePlayerModal extends LitElement {
                 .filter((ut): ut is UnitType => ut !== undefined),
               peaceTimerDurationMinutes: this.selectedPeaceTimerDuration,
               startingGold: this.startingGold,
+              goldMultiplier: this.goldMultiplier,
             },
           },
         } satisfies JoinLobbyEvent,

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -25,6 +25,8 @@ export const StartingGoldValues = [
   15_000_000, 20_000_000, 25_000_000, 35_000_000, 50_000_000,
 ] as const;
 
+export const GoldMultiplierValues = [1, 1.5, 2, 3, 4, 5, 10, 25, 50] as const;
+
 export type Intent =
   | SpawnIntent
   | AttackIntent
@@ -236,6 +238,10 @@ export const GameConfigSchema = z.object({
   startingGold: z
     .union(StartingGoldValues.map((value) => z.literal(value)))
     .default(0),
+  goldMultiplier: z
+    .union(GoldMultiplierValues.map((value) => z.literal(value)))
+    .optional()
+    .default(1),
 });
 
 export const TeamSchema = z.string();

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -1275,7 +1275,8 @@ export class DefaultConfig implements Config {
     const productivity = player.productivity();
     const k = player.effectiveUnits(UnitType.Factory);
     const factoryFactor = Math.pow(1 + k, 0.35);
-    const grossGold = base * productivity * factoryFactor;
+    const multiplier = this._gameConfig.goldMultiplier ?? 1;
+    const grossGold = base * productivity * factoryFactor * multiplier;
     return Number.isFinite(grossGold) && grossGold >= 0 ? grossGold : 0;
   }
 

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -53,6 +53,7 @@ export class GameManager {
         peaceTimerDurationMinutes:
           gameConfig?.peaceTimerDurationMinutes ?? PeaceTimerDuration.None,
         startingGold: 0,
+        goldMultiplier: gameConfig?.goldMultiplier ?? 1,
         ...gameConfig,
       },
       creatorClientID,

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -129,6 +129,9 @@ export class GameServer {
     if (gameConfig.startingGold !== undefined) {
       this.gameConfig.startingGold = gameConfig.startingGold;
     }
+    if (gameConfig.goldMultiplier !== undefined) {
+      this.gameConfig.goldMultiplier = gameConfig.goldMultiplier;
+    }
   }
 
   public addClient(client: Client, lastTurn: number) {

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -89,6 +89,7 @@ export class MapPlaylist {
       bots: 400,
       peaceTimerDurationMinutes: PeaceTimerDuration.None,
       startingGold: 0,
+      goldMultiplier: 1,
     } satisfies GameConfig;
   }
 

--- a/tests/GameServerAuthorization.test.ts
+++ b/tests/GameServerAuthorization.test.ts
@@ -103,6 +103,7 @@ const baseGameConfig: GameConfig = {
   instantBuild: false,
   peaceTimerDurationMinutes: PeaceTimerDuration.None,
   startingGold: 0,
+  goldMultiplier: 1,
 };
 
 const createLogger = (): Logger => {

--- a/tests/util/Setup.ts
+++ b/tests/util/Setup.ts
@@ -48,6 +48,7 @@ export async function setup(
     instantBuild: false,
     peaceTimerDurationMinutes: PeaceTimerDuration.None,
     startingGold: 0,
+    goldMultiplier: 1,
     ..._gameConfig,
   };
   const config = new TestConfig(


### PR DESCRIPTION
## Description:
- Added goldMultiplier to GameConfig schema (default 1x).
- Implemented gold multiplier logic in DefaultConfig.ts affecting grossGoldAdditionRate.
- Added Gold Multiplier dropdown to HostLobbyModal.ts and SinglePlayerModal.ts.
- Supported multipliers: 1x, 1.5x, 2x, 3x, 4x, 5x, 10x, 25x, 50x.
- Added translation for Gold Multiplier in en.json.
- Updated GameServer.ts to correctly persist goldMultiplier updates.
- Updated GameManager, MapPlaylist, and tests to include default goldMultiplier.

<img width="950" height="353" alt="image" src="https://github.com/user-attachments/assets/aa4d3073-7f3f-4461-8aaa-3118a6a9d890" />

<img width="320" height="558" alt="image" src="https://github.com/user-attachments/assets/45c25ab5-1607-43b8-a7e7-f725b4a13ab4" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
