### PR TITLE
Reduce Websocket Reconnections

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -637,7 +637,7 @@ export class ClientGameRunner {
     }
     const now = Date.now();
     const timeSinceLastMessage = now - this.lastMessageTime;
-    if (timeSinceLastMessage > 5000) {
+    if (timeSinceLastMessage > 15000) {
       console.log(
         `No message from server for ${timeSinceLastMessage} ms, reconnecting`,
       );

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -325,7 +325,6 @@ export class ClientGameRunner {
     requestAnimationFrame(keepWorkerAlive);
 
     const onconnect = () => {
-      console.log("Connected to game server!");
       this.transport.joinGame(this.turnsSeen);
     };
     const onmessage = (message: ServerMessage) => {

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -417,14 +417,32 @@ export class Transport {
     onconnect: () => void,
     onmessage: (message: ServerMessage) => void,
   ) {
-    this.startPing();
-    this.killExistingSocket();
     const wsHost = window.location.host;
     const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const workerPath = this.lobbyConfig.serverConfig.workerPath(
       this.lobbyConfig.gameID,
     );
-    this.socket = new WebSocket(`${wsProtocol}//${wsHost}/${workerPath}`);
+    const url = `${wsProtocol}//${wsHost}/${workerPath}`;
+
+    if (
+      this.socket !== null &&
+      this.socket.readyState === WebSocket.OPEN &&
+      this.socket.url === url
+    ) {
+      console.log("Reusing existing connection");
+      this.onconnect = onconnect;
+      this.onmessage = onmessage;
+      try {
+        this.onconnect();
+      } catch (err) {
+        console.error("Error in onconnect handler:", err);
+      }
+      return;
+    }
+
+    this.startPing();
+    this.killExistingSocket();
+    this.socket = new WebSocket(url);
     this.onconnect = onconnect;
     this.onmessage = onmessage;
     this.socket.onopen = () => {

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -333,6 +333,7 @@ export class GameServer {
             case "ping": {
               this.lastPingUpdate = Date.now();
               client.lastPing = Date.now();
+              client.ws.send(JSON.stringify({ type: "ping" }));
               break;
             }
             case "hash": {

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -340,6 +340,17 @@ export class GameServer {
               client.hashes.set(clientMsg.turnNumber, clientMsg.hash);
               break;
             }
+            case "join": {
+              this.log.info(
+                "Client requested re-join/sync via existing connection",
+                {
+                  clientID: client.clientID,
+                  lastTurn: clientMsg.lastTurn,
+                },
+              );
+              this.sendStartGameMsg(client.ws, clientMsg.lastTurn);
+              break;
+            }
             case "winner": {
               if (
                 this.outOfSyncClients.has(client.clientID) ||


### PR DESCRIPTION
This pull request introduces improvements to the client-server connection logic for the game, focusing on connection reuse, reconnection timing, and server message handling. The main goal is to make reconnections more efficient and robust by reusing existing WebSocket connections when possible, adjusting reconnection timeouts, and improving server-side handling of client re-join requests.

**Connection management improvements:**

* Added logic in the `Transport` class to reuse an existing WebSocket connection if it is already open and matches the required URL, reducing unnecessary reconnects and improving efficiency.
* Increased the client-side reconnection timeout from 5 seconds to 15 seconds in `ClientGameRunner`, making reconnections less aggressive and reducing potential server load.

**Server-side message handling:**

* Implemented support for a new `"join"` message type in the `GameServer` class, allowing clients to request a re-join/sync using an existing connection. The server responds by sending the appropriate start game message for the requested turn.
* Modified the server to send a `"ping"` response back to the client upon receiving a `"ping"` message, improving connection health monitoring.

**Minor cleanup:**

* Removed a console log message from the `ClientGameRunner` connection handler for less noisy output.
