### PR TITLE
Fix raw HTML rendering in Trade tab under construction view

### DIFF
--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -2195,16 +2195,16 @@ export class ControlPanel2 extends LitElement implements Layer {
         100,
         Math.max(0, Math.round(((delay - remaining) / delay) * 100)),
       );
-      return html`< div
-class="py-1 px-2 border-b"
-style = "border-color: var(--ui-panel-border)"
-  >
-  <div class="mb-1 text-gray-300" >
-    Cargo Ship #${idx + 1} (Port #${port.id()}) constructing…
-</div>
-  < div class="progress-track" style = "height:6px;" >
-    <div class="progress-fill" style = "width:${pct}%;" > </div>
-      </div>
+      return html`<div
+        class="py-1 px-2 border-b"
+        style="border-color: var(--ui-panel-border)"
+      >
+        <div class="mb-1 text-gray-300">
+          Cargo Ship #${idx + 1} (Port #${port.id()}) constructing…
+        </div>
+        <div class="progress-track" style="height:6px;">
+          <div class="progress-fill" style="width:${pct}%;"></div>
+        </div>
       </div>`;
     });
 


### PR DESCRIPTION
## Description:

Fix raw HTML rendering in Trade tab under construction view.

There were extra spaces in the HTML tags (e.g., < div) in ControlPanel2.ts that were causing the browser to render them as text instead of HTML.

New
<img width="632" height="234" alt="image" src="https://github.com/user-attachments/assets/99f63ac9-8ea2-4680-9952-1b770d268aea" />
Old
<img width="791" height="307" alt="image" src="https://github.com/user-attachments/assets/12d44a87-72f0-4fc4-8922-ea43be4de5fe" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
