### PR TITLE
Fix infinite gold not applying to fighter jets and airfield bomber upgrades

### DIFF
--- a/src/core/game/Costs.ts
+++ b/src/core/game/Costs.ts
@@ -39,6 +39,12 @@ export function aggregateStructureBuildCost(
   // For upgradeable units (Bomber, Fighter, Warship, Submarine), use hardcoded total costs
   const unitUpgrades = getUnitUpgradeData(type);
   if (unitUpgrades) {
+    // Check if infinite gold is enabled for human players
+    const base = unitInfoProvider.unitInfo(type).cost(player);
+    if (base === 0n) {
+      // If base cost is 0 (infinite gold enabled), return 0 for upgrades too
+      return 0n;
+    }
     // UnitUpgrades now stores total cost at each level, just return it directly
     return getUnitLevelCost(type, desiredLevel);
   }
@@ -68,8 +74,8 @@ type AirfieldCostProvider = {
  * Now uses hardcoded costs from UnitUpgrades instead of calculating.
  */
 export function computeBomberUpgradeCost(
-  _provider: AirfieldCostProvider,
-  _player: any,
+  provider: AirfieldCostProvider,
+  player: any,
   bomberLevel: number,
   _airfieldLevel: number = 1,
 ): Gold {
@@ -78,6 +84,12 @@ export function computeBomberUpgradeCost(
     Math.max(1, bomberLevel),
   );
   if (bLevel <= 1) return 0n;
+  // Check if infinite gold is enabled for human players via base bomber cost
+  const baseBomberCost = provider.unitInfo(UnitType.Bomber).cost(player);
+  if (baseBomberCost === 0n) {
+    // If base cost is 0 (infinite gold enabled), return 0 for upgrades too
+    return 0n;
+  }
   // Use hardcoded total cost from UnitUpgrades
   return getUnitLevelCost(UnitType.Bomber, bLevel);
 }


### PR DESCRIPTION
## Description:

When infinite gold is enabled in single player lobby, the base cost of units correctly becomes 0, but upgradeable units (Fighter jets) and airfield bomber upgrades were still using hardcoded costs from UnitUpgrades.ts.

This fix adds checks in aggregateStructureBuildCost() and computeBomberUpgradeCost() to detect when base cost is 0 (indicating infinite gold is enabled) and returns 0 for upgrade costs as well.

Fixes issue where airfields and fighters don't cost 0 when unlimited gold is selected in single player lobby.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777