### PR TITLE
Improve unit selection grid layout in singleplayer lobby

### DIFF
--- a/src/client/utilities/RenderUnitTypeOptions.ts
+++ b/src/client/utilities/RenderUnitTypeOptions.ts
@@ -38,7 +38,7 @@ export function renderUnitTypeOptions({
     ({ type, translationKey }) => html`
       <label
         class="option-card ${disabledUnits.includes(type) ? "" : "selected"}"
-        style="width: 140px;"
+        style="width: 115px;"
       >
         <div class="checkbox-icon"></div>
         <input


### PR DESCRIPTION
## Description:

Reduced unit selection card width from 140px to 115px in the Extra Settings section to optimize the grid layout. This change allows 6 unit cards to fit per row instead of 5, reducing the total from 3 rows to 2 rows for the 11 available structure types.

Benefits:
- Cleaner, more compact UI layout
- Better visual density without overcrowding 
- Improved consistency with modern grid patterns
- Start button in view

Affected file:
- src/client/utilities/RenderUnitTypeOptions.ts

<img width="2046" height="1087" alt="image" src="https://github.com/user-attachments/assets/7a72e7b3-8284-4116-9a0a-d57a5c572c5c" />

<img width="2036" height="1085" alt="image" src="https://github.com/user-attachments/assets/f13a839d-8950-476e-a08e-86a1c63b4467" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777