### PR TITLE
Fix research investment when no techs remain

### DIFF
--- a/src/client/ResearchTreeModal.ts
+++ b/src/client/ResearchTreeModal.ts
@@ -61,6 +61,15 @@ export class ResearchTreeModal extends LitElement {
   @state()
   private lockResearch = false;
 
+  private syncResearchInvestmentFromGame() {
+    const me = this.game?.myPlayer?.();
+    if (!me) return;
+    const serverRate = me.researchInvestmentRate?.() ?? 0;
+    if (Math.abs(serverRate - this.researchInvestmentRate) > 1e-6) {
+      this.researchInvestmentRate = serverRate;
+    }
+  }
+
   connectedCallback(): void {
     super.connectedCallback();
     window.addEventListener(
@@ -76,7 +85,11 @@ export class ResearchTreeModal extends LitElement {
   open() {
     this.modalEl?.open();
     this.requestInvestmentSync();
-    this.refreshTimer ??= window.setInterval(() => this.requestUpdate(), 500);
+    this.syncResearchInvestmentFromGame();
+    this.refreshTimer ??= window.setInterval(() => {
+      this.syncResearchInvestmentFromGame();
+      this.requestUpdate();
+    }, 500);
     this.eventBus.on(CloseViewEvent, this.close);
   }
 

--- a/src/client/graphics/layers/ControlPanel2.ts
+++ b/src/client/graphics/layers/ControlPanel2.ts
@@ -377,6 +377,14 @@ export class ControlPanel2 extends LitElement implements Layer {
     this._productivity = player.productivity();
     this._productivityGrowth = player.productivityGrowthPerMinute();
     this.investmentRate = player.investmentRate();
+    const serverResearchRate = player.researchInvestmentRate();
+    if (Math.abs(serverResearchRate - this._researchInvestmentRate) > 1e-6) {
+      this._researchInvestmentRate = serverResearchRate;
+      localStorage.setItem(
+        "settings.researchInvestmentRate",
+        this._researchInvestmentRate.toString(),
+      );
+    }
     // If Roads are not researched, force road investment to 0 and persist
     const hasRoadsUpgrade = player.hasUpgrade(UpgradeType.Roads);
     if (!hasRoadsUpgrade && this._roadInvestmentRate !== 0) {

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -8,6 +8,7 @@ import {
   UnitType,
   UpgradeType,
 } from "../game/Game";
+import { GameImpl } from "../game/GameImpl";
 import { TileRef } from "../game/GameMap";
 import { PseudoRandom } from "../PseudoRandom";
 import { getTechNodes, isTechAvailable } from "../tech/ResearchTree";
@@ -25,7 +26,7 @@ const traversalStates = new WeakMap<Game, ClusterTraversalState>();
 
 export class PlayerExecution implements Execution {
   private config: Config;
-  private mg: Game;
+  private mg: GameImpl;
   private active = true;
   private random: PseudoRandom | null = null;
   // Accumulate research "intensity" allocation since last innovation calculation
@@ -41,7 +42,7 @@ export class PlayerExecution implements Execution {
   }
 
   init(mg: Game, ticks: number) {
-    this.mg = mg;
+    this.mg = mg as GameImpl;
     this.config = mg.config();
     this.random = new PseudoRandom(ticks + simpleHash(this.player.id()));
   }
@@ -208,7 +209,13 @@ export class PlayerExecution implements Execution {
     const available = nodes.filter(
       (n) => !researched.has(n.id) && isTechAvailable(n.id, researched),
     );
-    if (available.length === 0) return;
+    if (available.length === 0) {
+      if (this.player.researchInvestmentRate?.() ?? 0 > 0) {
+        this.player.setResearchInvestmentRate(0);
+        this.mg.addUpdate(this.player.toUpdate());
+      }
+      return;
+    }
 
     // Get all priorities and check which are available
     const allPriorities: Set<string> =


### PR DESCRIPTION
## Description:

When a player has no available research left (either because all techs are unlocked from the start, or because everything gets completed mid-game), the research investment slider could remain non-zero and keep deducting gold.

This happened because the client UI could keep using a default/localStorage value and continue sending it, even after the server had nothing left to spend research on.

## Fix
- Server-side: if there are no available techs to research, force `researchInvestmentRate` to `0` and emit a player update so clients see the reset.
- Client-side: keep the UI sliders authoritative to the server value (`player.researchInvestmentRate()`), so defaults/localStorage can’t “stick” and re-apply a non-zero investment.
  - Control panel slider sync
  - Research tree modal slider sync

## Why this is safe
- Only affects the case where there is nothing left to research.
- If research is available, the investment rate behaves as before.

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`
- manual testing



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
