### PR TITLE
Neutral AA targeting (cities & SAMs) with SAM nuke self-defense

### DIFF
--- a/src/core/execution/CityAABulletExecution.ts
+++ b/src/core/execution/CityAABulletExecution.ts
@@ -91,10 +91,12 @@ export class CityAABulletExecution implements Execution {
     }
 
     // Check if target is still valid
+    const targetOwner = this.target.owner();
     if (
       !this.target.isActive() ||
-      this.target.owner() === this.bullet.owner() ||
-      this._owner.isFriendly(this.target.owner())
+      targetOwner === this.bullet.owner() ||
+      this._owner.isFriendly(targetOwner) ||
+      !this.canEngageTarget(targetOwner, this.target)
     ) {
       console.log(
         `AA bullet missed: target ${!this.target.isActive() ? "destroyed" : "became friendly"}`,
@@ -171,6 +173,31 @@ export class CityAABulletExecution implements Execution {
     this.bullet!.setReachedTarget();
     this.bullet!.delete(false);
     this.active = false;
+  }
+
+  private canEngageTarget(targetOwner: Player, target: Unit): boolean {
+    if (this.isAtWarEffective(targetOwner)) {
+      return true;
+    }
+
+    // Neutral behavior: only defend against explicit incoming attacks.
+    if (
+      target.type() !== UnitType.Bomber &&
+      target.type() !== UnitType.Paratrooper
+    ) {
+      return false;
+    }
+
+    const targetTile = target.targetTile();
+    if (targetTile === undefined) {
+      return false;
+    }
+
+    return this.mg.owner(targetTile) === this._owner;
+  }
+
+  private isAtWarEffective(other: Player): boolean {
+    return this._owner.isAtWarWith(other);
   }
 
   isActive(): boolean {

--- a/src/core/execution/CityAAExecution.ts
+++ b/src/core/execution/CityAAExecution.ts
@@ -83,10 +83,13 @@ export class CityAAExecution implements Execution {
         .nearbyUnits(city.tile(), Math.sqrt(rangeSquared), planeType)
         .filter(({ unit }) => {
           const owner = unit.owner();
+          if (owner === this.player) {
+            return false;
+          }
           return (
             unit.isActive() &&
-            owner !== this.player &&
             !this.player.isFriendly(owner) &&
+            this.canEngagePlane(owner, unit) &&
             !unit.isAtSourceAirfield() // Don't target planes at their airfield
           );
         });
@@ -100,6 +103,32 @@ export class CityAAExecution implements Execution {
     }
 
     return nearestPlane;
+  }
+
+  private canEngagePlane(planeOwner: Player, plane: Unit): boolean {
+    if (this.isAtWarEffective(planeOwner)) {
+      return true;
+    }
+
+    // Neutral behavior: only defend against explicit incoming attacks.
+    // - Bomber / Paratrooper: allowed only if their targetTile is land owned by us.
+    if (
+      plane.type() !== UnitType.Bomber &&
+      plane.type() !== UnitType.Paratrooper
+    ) {
+      return false;
+    }
+
+    const targetTile = plane.targetTile();
+    if (targetTile === undefined) {
+      return false;
+    }
+
+    return this.mg.owner(targetTile) === this.player;
+  }
+
+  private isAtWarEffective(other: Player): boolean {
+    return this.player.isAtWarWith(other);
   }
 
   isActive(): boolean {

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -101,8 +101,22 @@ class SAMTargetingSystem {
       detectionRange,
       [UnitType.AtomBomb, UnitType.HydrogenBomb],
       ({ unit }) => {
+        if (!isUnit(unit)) {
+          return false;
+        }
+
+        const nukeOwner = unit.owner();
+        if (nukeOwner === this.player) {
+          return false;
+        }
+        if (this.player.isFriendly(nukeOwner)) {
+          return false;
+        }
+
+        // Only intercept neutral nukes if they are actually threatening us.
         return (
-          unit.owner() !== this.player && !this.player.isFriendly(unit.owner())
+          this.player.isAtWarWith(nukeOwner) ||
+          this.nukeThreatensPlayerTerritory(unit, this.player)
         );
       },
     );
@@ -146,6 +160,48 @@ class SAMTargetingSystem {
         return 0;
       })
       .slice(0, maxCount);
+  }
+
+  private nukeThreatensPlayerTerritory(nuke: Unit, player: Player): boolean {
+    const targetTile = nuke.targetTile();
+    if (targetTile === undefined) {
+      return false;
+    }
+
+    const playerSmallID = player.smallID();
+    if (this.mg.ownerID(targetTile) === playerSmallID) {
+      return true;
+    }
+
+    const blastRadius = this.mg.config().nukeMagnitudes(nuke.type()).outer;
+    const outer2 = blastRadius * blastRadius;
+
+    // PERF: Avoid bfs() here (allocates a Set + queue) since this can run often.
+    // A tight bounding-box scan with early exit is faster and allocation-free.
+    const tx = this.mg.x(targetTile);
+    const ty = this.mg.y(targetTile);
+    const minX = Math.max(0, tx - blastRadius);
+    const maxX = Math.min(this.mg.width() - 1, tx + blastRadius);
+    const minY = Math.max(0, ty - blastRadius);
+    const maxY = Math.min(this.mg.height() - 1, ty + blastRadius);
+
+    for (let y = minY; y <= maxY; y++) {
+      const dy = y - ty;
+      const dy2 = dy * dy;
+      for (let x = minX; x <= maxX; x++) {
+        const dx = x - tx;
+        if (dx * dx + dy2 > outer2) {
+          continue;
+        }
+
+        const ref = this.mg.ref(x, y);
+        if (this.mg.ownerID(ref) === playerSmallID) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }
 

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -383,6 +383,12 @@ export class SAMLauncherExecution implements Execution {
         if (unitOwner === this.player) return false;
 
         if (this.player.isFriendly(unitOwner as Player)) return false;
+
+        // Neutral behavior: only intercept when at war, except defend against
+        // bomber/paratrooper explicitly targeting our land.
+        if (!this.canEngageAirborneTarget(unitOwner as Player, unit)) {
+          return false;
+        }
         if (
           targetUnitOwner === this.player ||
           (targetUnitOwner &&
@@ -458,6 +464,27 @@ export class SAMLauncherExecution implements Execution {
         );
       }
     }
+  }
+
+  private canEngageAirborneTarget(unitOwner: Player, unit: Unit): boolean {
+    if (this.player.isAtWarWith(unitOwner)) {
+      return true;
+    }
+
+    // Neutral: only defend against incoming bomber/paratrooper attacks.
+    if (
+      unit.type() !== UnitType.Bomber &&
+      unit.type() !== UnitType.Paratrooper
+    ) {
+      return false;
+    }
+
+    const targetTile = unit.targetTile();
+    if (targetTile === undefined) {
+      return false;
+    }
+
+    return this.mg.owner(targetTile) === this.player;
   }
 
   isActive(): boolean {

--- a/src/core/execution/utils/CityAntiAirUtils.ts
+++ b/src/core/execution/utils/CityAntiAirUtils.ts
@@ -2,8 +2,10 @@ import { Game, Player, Unit, UnitType, UpgradeType } from "../../game/Game";
 import { SAMMissileExecution } from "../SAMMissileExecution";
 
 /**
- * Finds all enemy cities with the CityAntiAir upgrade within the nuke's blast radius.
- * Used for SAM missile interception of nukes.
+ * Finds all non-friendly cities with the CityAntiAir upgrade within the nuke's blast radius.
+ *
+ * Note: This is already "targeting-based" for neutral players because we only consider
+ * cities that are threatened by the nuke's target (blast-radius check).
  */
 export function findEligibleCitiesForNuke(nuke: Unit, game: Game): Unit[] {
   const nukeOwner = nuke.owner();

--- a/tests/core/executions/CityAAExecutionNeutrality.test.ts
+++ b/tests/core/executions/CityAAExecutionNeutrality.test.ts
@@ -1,0 +1,107 @@
+import { CityAAExecution } from "../../../src/core/execution/CityAAExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  Unit,
+  UnitType,
+  UpgradeType,
+} from "../../../src/core/game/Game";
+import { setup } from "../../util/Setup";
+import { TestConfig } from "../../util/TestConfig";
+import { executeTicks } from "../../util/utils";
+
+let game: Game;
+let defender: Player;
+let attacker: Player;
+let attackerAirfield: Unit;
+
+async function setupCityAA(): Promise<void> {
+  game = await setup("BigPlains", { infiniteGold: true, instantBuild: true }, [
+    new PlayerInfo("us", "defender", PlayerType.Human, "client_def", "def_id"),
+    new PlayerInfo("us", "attacker", PlayerType.Human, "client_att", "att_id"),
+  ]);
+
+  while (game.inSpawnPhase()) {
+    game.executeNextTick();
+  }
+
+  defender = game.player("def_id");
+  attacker = game.player("att_id");
+
+  // Make City AA deterministic + fast.
+  const cfg = game.config() as TestConfig;
+  cfg.cityAAFireRate = jest.fn(() => 1);
+  cfg.cityAARange = jest.fn(() => 6);
+  cfg.cityAABulletSpeed = jest.fn(() => 6);
+  cfg.cityAABulletDamage = jest.fn(() => 999_999);
+
+  // Defender city + ownership
+  defender.conquer(game.ref(10, 10));
+  defender.conquer(game.ref(10, 11));
+  defender.conquer(game.ref(11, 11));
+  defender.buildUnit(UnitType.City, game.ref(10, 10), {});
+
+  // Attacker airfield just to satisfy bomber metadata (sourceAirfield)
+  attacker.conquer(game.ref(30, 30));
+  attackerAirfield = attacker.buildUnit(
+    UnitType.Airfield,
+    game.ref(30, 30),
+    {},
+  );
+
+  defender.addUpgrade(UpgradeType.CityAntiAir);
+  game.addExecution(new CityAAExecution(defender));
+}
+
+describe("CityAAExecution neutrality", () => {
+  beforeEach(async () => {
+    await setupCityAA();
+  });
+
+  test("neutral: city AA does not shoot bomber unless bomber targets defender land", () => {
+    // Bomber near city, but targeting attacker-owned land.
+    attacker.conquer(game.ref(40, 40));
+    const bomber = attacker.buildUnit(UnitType.Bomber, game.ref(11, 10), {
+      targetTile: game.ref(40, 40),
+      sourceAirfield: attackerAirfield,
+    });
+
+    executeTicks(game, 8);
+    expect(bomber.isActive()).toBe(true);
+  });
+
+  test("neutral: city AA shoots bomber when bomber targets defender land", () => {
+    const bomber = attacker.buildUnit(UnitType.Bomber, game.ref(11, 10), {
+      targetTile: game.ref(10, 11),
+      sourceAirfield: attackerAirfield,
+    });
+
+    executeTicks(game, 8);
+    expect(bomber.isActive()).toBe(false);
+  });
+
+  test("neutral: city AA shoots paratrooper when paratrooper targets defender land", () => {
+    const paratrooper = attacker.buildUnit(
+      UnitType.Paratrooper,
+      game.ref(11, 10),
+      {
+        troops: 10,
+        targetTile: game.ref(11, 11),
+      },
+    );
+
+    executeTicks(game, 8);
+    expect(paratrooper.isActive()).toBe(false);
+  });
+
+  test("neutral: city AA does not shoot fighter jets", () => {
+    const fighter = attacker.buildUnit(UnitType.FighterJet, game.ref(11, 10), {
+      patrolTile: game.ref(0, 0),
+    });
+
+    executeTicks(game, 8);
+    expect(fighter.isActive()).toBe(true);
+  });
+});

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -85,6 +85,9 @@ describe("SAM", () => {
   });
 
   test("one sam should take down one nuke", async () => {
+    attacker.setWarWith(defender);
+    defender.setWarWith(attacker);
+
     const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
     game.addExecution(new SAMLauncherExecution(defender, null, sam));
 
@@ -103,6 +106,9 @@ describe("SAM", () => {
   });
 
   test("sam should only get one nuke at a time", async () => {
+    attacker.setWarWith(defender);
+    defender.setWarWith(attacker);
+
     const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
     game.addExecution(new SAMLauncherExecution(defender, null, sam));
     attacker.buildUnit(UnitType.AtomBomb, game.ref(2, 1), {
@@ -129,6 +135,9 @@ describe("SAM", () => {
   });
 
   test("sam should cooldown as long as configured", async () => {
+    attacker.setWarWith(defender);
+    defender.setWarWith(attacker);
+
     const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
     game.addExecution(new SAMLauncherExecution(defender, null, sam));
     expect(sam.isInCooldown()).toBeFalsy();
@@ -155,6 +164,9 @@ describe("SAM", () => {
   });
 
   test("two sams should not target twice same nuke", async () => {
+    attacker.setWarWith(defender);
+    defender.setWarWith(attacker);
+
     const sam1 = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
     game.addExecution(new SAMLauncherExecution(defender, null, sam1));
     const sam2 = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 2), {});
@@ -175,6 +187,9 @@ describe("SAM", () => {
   });
 
   test("SAMs should target close to launch site", async () => {
+    attacker.setWarWith(defender);
+    defender.setWarWith(attacker);
+
     const targetDistance = 199;
     // Close SAM: should intercept the nuke
     const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
@@ -198,6 +213,13 @@ describe("SAM", () => {
   });
 
   test("SAMs should target only nukes aimed at nearby targets if not close to launch site", async () => {
+    attacker.setWarWith(defender);
+    defender.setWarWith(attacker);
+    attacker.setWarWith(middle_defender);
+    middle_defender.setWarWith(attacker);
+    attacker.setWarWith(far_defender);
+    far_defender.setWarWith(attacker);
+
     const targetDistance = 199;
     // Middle SAM: should not intercept the nuke
     const sam1 = middle_defender.buildUnit(
@@ -259,5 +281,43 @@ describe("SAM", () => {
     executeTicks(game, 25);
 
     expect(bomber.targetedBySAM()).toBe(true);
+  });
+
+  test("neutral: SAM should not intercept a nuke that does not threaten its territory", async () => {
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Nuke travels near the SAM but is targeted far away (blast radius doesn't touch defender land).
+    const nuke = attacker.buildUnit(UnitType.AtomBomb, game.ref(2, 1), {
+      targetTile: game.ref(199, 199),
+      trajectory: [
+        { tile: game.ref(2, 1), targetable: true },
+        { tile: game.ref(2, 2), targetable: true },
+        { tile: game.ref(2, 3), targetable: true },
+      ],
+    });
+
+    executeTicks(game, 5);
+
+    expect(nuke.targetedBySAM()).toBe(false);
+    expect(sam.isInCooldown()).toBeFalsy();
+  });
+
+  test("neutral: SAM should intercept a nuke whose blast radius threatens its territory", async () => {
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Target near defender so blast radius overlaps defender-owned tiles.
+    const nuke = attacker.buildUnit(UnitType.AtomBomb, game.ref(2, 1), {
+      targetTile: game.ref(3, 1),
+      trajectory: [
+        { tile: game.ref(2, 1), targetable: true },
+        { tile: game.ref(3, 1), targetable: true },
+      ],
+    });
+
+    executeTicks(game, 5);
+
+    expect(nuke.targetedBySAM()).toBe(true);
   });
 });

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -231,4 +231,33 @@ describe("SAM", () => {
     expect(sam1.isInCooldown()).toBeFalsy();
     expect(sam2.isInCooldown()).toBeTruthy();
   });
+
+  test("neutral: SAM should not intercept bomber unless bomber targets defender land", async () => {
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Bomber in range but targeting attacker land.
+    const bomber = attacker.buildUnit(UnitType.Bomber, game.ref(2, 1), {
+      targetTile: game.ref(7, 7),
+    });
+
+    // Run enough ticks to hit the 20-tick plane interception sweep.
+    executeTicks(game, 25);
+
+    expect(bomber.targetedBySAM()).toBe(false);
+  });
+
+  test("neutral: SAM should intercept bomber when bomber targets defender land", async () => {
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Bomber in range and targeting a tile owned by defender.
+    const bomber = attacker.buildUnit(UnitType.Bomber, game.ref(2, 1), {
+      targetTile: game.ref(1, 1),
+    });
+
+    executeTicks(game, 25);
+
+    expect(bomber.targetedBySAM()).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description:

- Align anti-air behavior with diplomacy: engage when at war; if neutral, only self-defend against explicit threats.
- City AA and SAM plane interception now share the same neutral gating; SAM nuke interception gains a neutral self-defense rule and perf-safe threat check.

## What changed (by area)
- City AA (planes):
	- [src/core/execution/CityAAExecution.ts](src/core/execution/CityAAExecution.ts) now targets planes only when at war, except neutral self-defense for Bomber/Paratrooper whose `targetTile` is owned by the city’s player.
	- [src/core/execution/CityAABulletExecution.ts](src/core/execution/CityAABulletExecution.ts) revalidates the same diplomacy/targeting rule mid-flight so peace changes do not result in stray hits.
	- Comment clarification in [src/core/execution/utils/CityAntiAirUtils.ts](src/core/execution/utils/CityAntiAirUtils.ts) about nuke eligibility being blast-radius based.

- SAM launchers (planes):
	- [src/core/execution/SAMLauncherExecution.ts](src/core/execution/SAMLauncherExecution.ts) plane interception is now war-gated, with neutral self-defense for Bomber/Paratrooper targeting defender-owned land; fighters/cargo remain war-only.

- SAM launchers (nukes):
	- Neutral SAMs no longer shoot nukes just because they’re non-friendly/in-range. They now intercept when at war, or (if neutral) only when the nuke’s outer blast radius around `targetTile` overlaps defender territory (self-defense).
	- Threat detection is now allocation-free: bounding-box + circle check using `ownerID`/`smallID` instead of `bfs` Set/queue allocation.

- Tests:
	- New regression suite [tests/core/executions/CityAAExecutionNeutrality.test.ts](tests/core/executions/CityAAExecutionNeutrality.test.ts) for city AA neutrality (bomber/paratrooper targeting vs not, fighter ignored).
	- Updated [tests/core/executions/SAMLauncherExecution.test.ts](tests/core/executions/SAMLauncherExecution.test.ts):
		- Plane neutrality (bomber targeting self-defense vs not).
		- Nuke neutrality: neutral non-threat (no intercept) and neutral self-defense (intercept); war scenarios now explicitly declare war.

## Rationale / correctness
- Prevents neutral AA from acting as a de-facto hostile unless actually threatened.
- Self-defense is tied to intent: bomber/paratrooper `targetTile` or nuke blast footprint overlapping defender land.
- Mid-flight revalidation avoids stale bullets hitting after diplomacy changes.

## Performance notes
- Nuke threat check avoids `bfs` allocation; uses tight bounding-box + circle distance and ownerID lookup with early exit.

## Testing
- npm test
- npm run lint
- npx tsc -p tsconfig.json --noEmit


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777