### PR TITLE
Betrayal Immediately Creates War State

### DIFF
--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -838,6 +838,13 @@ export class GameImpl implements Game {
         `${breaker} not allied with ${other}, cannot break alliance`,
       );
     }
+
+    // Betrayal immediately creates a war state (separate from relations).
+    breaker.setWarWith(other);
+    other.setWarWith(breaker);
+    breaker.recordAggression(other);
+    other.recordAggression(breaker);
+
     if (!other.isTraitor() && !other.isDisconnected()) {
       breaker.markTraitor();
     }

--- a/tests/core/game/GameImpl.test.ts
+++ b/tests/core/game/GameImpl.test.ts
@@ -3,6 +3,7 @@ import { SpawnExecution } from "../../../src/core/execution/SpawnExecution";
 //import { TransportShipExecution } from "../../../src/core/execution/TransportShipExecution";
 import { AllianceRequestExecution } from "../../../src/core/execution/alliance/AllianceRequestExecution";
 import { AllianceRequestReplyExecution } from "../../../src/core/execution/alliance/AllianceRequestReplyExecution";
+import { BreakAllianceExecution } from "../../../src/core/execution/alliance/BreakAllianceExecution";
 import {
   Game,
   Player,
@@ -119,6 +120,35 @@ describe("GameImpl", () => {
     } while (attacker.outgoingAttacks().length > 0);
 
     expect(attacker.isTraitor()).toBe(true);
+  });
+
+  test("Breaking alliance immediately creates war", async () => {
+    jest.spyOn(attacker, "canSendAllianceRequest").mockReturnValue(true);
+    game.addExecution(new AllianceRequestExecution(attacker, defender.id()));
+
+    game.executeNextTick();
+    game.executeNextTick();
+
+    game.addExecution(
+      new AllianceRequestReplyExecution(attacker.id(), defender, true),
+    );
+
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(attacker.allianceWith(defender)).toBeTruthy();
+    expect(defender.allianceWith(attacker)).toBeTruthy();
+
+    game.addExecution(new BreakAllianceExecution(attacker, defender.id()));
+
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(attacker.allianceWith(defender)).toBeNull();
+    expect(defender.allianceWith(attacker)).toBeNull();
+
+    expect(attacker.isAtWarWith(defender)).toBe(true);
+    expect(defender.isAtWarWith(attacker)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description:

Makes breaking an alliance (betrayal) immediately create mutual war state between both players, ensuring that clicking the "betray" button puts you at war with your former ally.

## Problem
Previously, betrayal had inconsistent war state handling:
- Clicking "betray" → marked as traitor, relations tanked, alliance ended, **but NOT at war**
- Attack/nuke an ally → war declared, then alliance breaks (also marked traitor)

This meant you could betray an ally but remain technically "not at war" until you actually attacked them, which was confusing and inconsistent with the aggressive nature of betrayal.

## Solution
Modified `GameImpl.breakAlliance()` to:
1. Call `setWarWith()` mutually on both players
2. Record aggression for both players
3. Then proceed with existing traitor marking logic

This ensures ALL alliance breaks (whether from UI betrayal or hostile actions) create war state.

## Technical Changes

### Core Implementation
**`src/core/game/GameImpl.ts`**
- Added war state creation and aggression recording in `breakAlliance()` method
- Applies before traitor check, ensuring war is established regardless of disconnect status

```typescript
// Betrayal immediately creates a war state (separate from relations).
breaker.setWarWith(other);
other.setWarWith(breaker);
breaker.recordAggression(other);
other.recordAggression(breaker);
```

### Test Coverage
**`tests/core/game/GameImpl.test.ts`**
- Added "Breaking alliance immediately creates war" test
- Confirms alliance break → mutual war state (`isAtWarWith` returns true for both)
- Uses `BreakAllianceExecution` to simulate UI "betray" button

## Impact on Existing Flows
- **Attack/nuke/MIRV an ally**: No change (these already set war before breaking alliance)
- **UI "betray" button**: Now also sets war (new behavior)
- **Relation penalties**: Unchanged (still applied by `BreakAllianceExecution`)
- **Traitor marking**: Unchanged (still only marks if other isn't traitor/disconnected)

## Testing
- All existing tests pass (294/294)
- New test confirms betrayal → war behavior
- TypeScript compilation passes with no errors
- ESLint passes with no warnings

## Gameplay Impact
Players who betray allies will now:
- Immediately have war declared mutually
- Auto-embargo activated (existing behavior from `setWarWith`)
- See "At war with [player]" message (existing war declaration flow)
- Trigger all war-state checks (embargo enforcement, targeting, etc.)

This makes betrayal a more definitive hostile act with immediate strategic consequences.


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

el_magico777
